### PR TITLE
Implement "Like" feature + load time optimizations

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,7 +6,7 @@ import { CssBaseline } from "@mui/material";
 // import Button from "@mui/material/Button";
 
 import { CognitoUserProvider } from "containers/CognitoUserProvider/CognitoUserProvider";
-import { UserTablatureProvider } from "containers/UserTablatureProvider/UserTablatureProvider"
+import { TablatureProvider } from "containers/TablatureProvider/TablatureProvider"
 import Home from "pages/Home/Home";
 
 function App() {
@@ -18,9 +18,9 @@ function App() {
       <CognitoUserProvider>
         <CssBaseline />
         {/* <Button onClick={() => setLight((prev) => !prev)}>Toggle Theme</Button> */}
-        <UserTablatureProvider>
+        <TablatureProvider>
           <Home />
-        </UserTablatureProvider>
+        </TablatureProvider>
       </CognitoUserProvider>
     </ThemeProvider>
   );

--- a/src/App.js
+++ b/src/App.js
@@ -6,6 +6,7 @@ import { CssBaseline } from "@mui/material";
 // import Button from "@mui/material/Button";
 
 import { CognitoUserProvider } from "containers/CognitoUserProvider/CognitoUserProvider";
+import { UserTablatureProvider } from "containers/UserTablatureProvider/UserTablatureProvider"
 import Home from "pages/Home/Home";
 
 function App() {
@@ -17,7 +18,9 @@ function App() {
       <CognitoUserProvider>
         <CssBaseline />
         {/* <Button onClick={() => setLight((prev) => !prev)}>Toggle Theme</Button> */}
-        <Home />
+        <UserTablatureProvider>
+          <Home />
+        </UserTablatureProvider>
       </CognitoUserProvider>
     </ThemeProvider>
   );

--- a/src/components/Card/Card.test.js
+++ b/src/components/Card/Card.test.js
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react"
-import Card from './Card'
+import { BrowserRouter } from "react-router-dom";
+import Card from './Card';
 
 const testTab = {
   tags: [],
@@ -28,7 +29,7 @@ test('isExpanded false shows only the first bar', async ()=> {
     user={{username: 'JarJar_Binks'}} 
     handleExpand={() => null}
     isExpanded={false}
-  />)
+  />, {wrapper: BrowserRouter})
 
   expect(screen.getByText('test inputs A')).toBeInTheDocument()
   expect(screen.queryByText('test inputs B')).not.toBeInTheDocument()
@@ -40,7 +41,7 @@ test('isExpanded true shows additional bars', async ()=> {
     user={{username: 'JarJar_Binks'}} 
     handleExpand={() => null}
     isExpanded={true}
-  />)
+  />, {wrapper: BrowserRouter})
   expect(screen.getByText('test inputs A')).toBeInTheDocument()
   expect(screen.getByText('test inputs B')).toBeInTheDocument()
 })

--- a/src/components/Card/components/FavoriteIconButton/FavoriteIconButton.js
+++ b/src/components/Card/components/FavoriteIconButton/FavoriteIconButton.js
@@ -1,7 +1,7 @@
 // Components / hooks
 import { useContext, useEffect, useState } from "react";
 import { UserContext } from "containers/CognitoUserProvider/CognitoUserProvider";
-import { TablatureContext } from "containers/UserTablatureProvider/UserTablatureProvider";
+import { TablatureContext } from "containers/TablatureProvider/TablatureProvider";
 import { useNavigate } from "react-router-dom";
 
 // Services / Utils

--- a/src/components/Card/components/FavoriteIconButton/FavoriteIconButton.js
+++ b/src/components/Card/components/FavoriteIconButton/FavoriteIconButton.js
@@ -9,15 +9,16 @@ import { getIdTokenFromUser } from "utils/userUtils";
 import { handleLikingTablature } from 'services/profileServices'
 
 // MUI
-import { IconButton } from "@mui/material";
 import FavoriteBorderIcon from "@mui/icons-material/FavoriteBorder";
 import FavoriteIcon from '@mui/icons-material/Favorite';
+import ToggledIconButton from "components/ToggledIconButton/ToggledIconButton";
 
 const FavoriteIconButton = (props) => {
   const navigate = useNavigate()
   const { user } = useContext(UserContext)
   const { addToUsersLikedTablature, removeFromUsersLikedTablature } = useContext(TablatureContext)
-  const [likedByCurrentUser, setLikedByCurrentUser] = useState(user?.profile?.favoriteTabHash[props.tab_id] ? true : false)
+  const [likedByCurrentUser, setLikedByCurrentUser] = useState()
+  const [ownedByUser, setOwnedByUser] = useState()
 
   const handleClick = (action) => {
     if(user) {
@@ -38,27 +39,22 @@ const FavoriteIconButton = (props) => {
     if(user) {
       const likeStatus = user.profile?.favoriteTabHash[props.tab_id] ? true : false
       setLikedByCurrentUser(likeStatus)
+      setOwnedByUser(user.username === props.tabOwner)
     }
-  }, [user, props.tab_id])
+  }, [user, props])
 
   return (
     <>
-      {likedByCurrentUser 
-        ?
-          <IconButton 
-            disabled={props.isDisabled} 
-            onClick={() => handleClick('unlike')}
-          >
-            <FavoriteIcon />
-          </IconButton>
-        :
-          <IconButton 
-            disabled={props.isDisabled} 
-            onClick={() => handleClick('like')}
-          >
-            <FavoriteBorderIcon />
-          </IconButton>
-      }
+      <ToggledIconButton
+        isDisabled={ownedByUser}
+        startOnA={likedByCurrentUser}
+        iconA={<FavoriteIcon />}
+        titleA={""}
+        handleClickA={() => handleClick('unlike')}
+        iconB={<FavoriteBorderIcon />}
+        titleB={""}
+        handleClickB={() => handleClick('like')}
+      />
     </>
   );
 }

--- a/src/components/Card/components/FavoriteIconButton/FavoriteIconButton.js
+++ b/src/components/Card/components/FavoriteIconButton/FavoriteIconButton.js
@@ -1,12 +1,65 @@
+// Components / hooks
+import { useContext, useEffect, useState } from "react";
+import { UserContext } from "containers/CognitoUserProvider/CognitoUserProvider";
+import { TablatureContext } from "containers/UserTablatureProvider/UserTablatureProvider";
+import { useNavigate } from "react-router-dom";
+
+// Services / Utils
+import { getIdTokenFromUser } from "utils/userUtils";
+import { handleLikingTablature } from 'services/profileServices'
+
 // MUI
 import { IconButton } from "@mui/material";
 import FavoriteBorderIcon from "@mui/icons-material/FavoriteBorder";
+import FavoriteIcon from '@mui/icons-material/Favorite';
 
 const FavoriteIconButton = (props) => {
+  const navigate = useNavigate()
+  const { user } = useContext(UserContext)
+  const { addToUsersLikedTablature, removeFromUsersLikedTablature } = useContext(TablatureContext)
+  const [likedByCurrentUser, setLikedByCurrentUser] = useState(user?.profile?.favoriteTabHash[props.tab_id] ? true : false)
+
+  const handleClick = (action) => {
+    if(user) {
+      if(action === 'like') {
+        addToUsersLikedTablature(props.tab_id)  
+      } else {
+        removeFromUsersLikedTablature(props.tab_id)
+      }
+      const idToken = getIdTokenFromUser(user);
+      handleLikingTablature(action, user.profile._id, props.tab_id, idToken)
+      setLikedByCurrentUser(!likedByCurrentUser)
+    } else {
+      navigate("/login")
+    }
+  }
+
+  useEffect(() => {
+    if(user) {
+      const likeStatus = user.profile?.favoriteTabHash[props.tab_id] ? true : false
+      setLikedByCurrentUser(likeStatus)
+    }
+  }, [user, props.tab_id])
+
   return (
-    <IconButton disabled={props.isDisabled}>
-      <FavoriteBorderIcon />
-    </IconButton>
+    <>
+      {likedByCurrentUser 
+        ?
+          <IconButton 
+            disabled={props.isDisabled} 
+            onClick={() => handleClick('unlike')}
+          >
+            <FavoriteIcon />
+          </IconButton>
+        :
+          <IconButton 
+            disabled={props.isDisabled} 
+            onClick={() => handleClick('like')}
+          >
+            <FavoriteBorderIcon />
+          </IconButton>
+      }
+    </>
   );
 }
  

--- a/src/components/Card/components/FavoriteIconButton/FavoriteIconButton.test.js
+++ b/src/components/Card/components/FavoriteIconButton/FavoriteIconButton.test.js
@@ -1,14 +1,15 @@
-import { render, screen } from '@testing-library/react'
-import FavoriteIconButton from './FavoriteIconButton'
+import { render, screen } from "@testing-library/react";
+import FavoriteIconButton from "./FavoriteIconButton";
+import { BrowserRouter } from "react-router-dom";
 
 test('FavoriteIconButton is disabled if isDisabled is true', ()=> {
-  render(<FavoriteIconButton isDisabled={true}/>)
+  render(<FavoriteIconButton isDisabled={true}/>, {wrapper: BrowserRouter})
   const button = screen.getByRole('button')
   expect(button).toHaveAttribute('disabled')
 })
 
 test('FavoriteIconButton is enabled if isDisabled is false', ()=> {
-  render(<FavoriteIconButton isDisabled={false}/>)
+  render(<FavoriteIconButton isDisabled={false}/>, {wrapper: BrowserRouter})
   const button = screen.getByRole('button')
   expect(button).not.toHaveAttribute('disabled')
 })

--- a/src/components/Card/components/FavoriteIconButton/FavoriteIconButton.test.js
+++ b/src/components/Card/components/FavoriteIconButton/FavoriteIconButton.test.js
@@ -1,15 +1,18 @@
 import { render, screen } from "@testing-library/react";
 import FavoriteIconButton from "./FavoriteIconButton";
+import userEvent from "@testing-library/user-event";
 import { BrowserRouter } from "react-router-dom";
 
-test('FavoriteIconButton is disabled if isDisabled is true', ()=> {
-  render(<FavoriteIconButton isDisabled={true}/>, {wrapper: BrowserRouter})
-  const button = screen.getByRole('button')
-  expect(button).toHaveAttribute('disabled')
-})
+const mockedNavigate = jest.fn()
 
-test('FavoriteIconButton is enabled if isDisabled is false', ()=> {
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockedNavigate
+}));
+
+test('navigates non users to login when clicked', async ()=> {
   render(<FavoriteIconButton isDisabled={false}/>, {wrapper: BrowserRouter})
-  const button = screen.getByRole('button')
-  expect(button).not.toHaveAttribute('disabled')
+  const user = userEvent.setup()
+  await user.click(screen.getByRole('button'))
+  expect(mockedNavigate).toHaveBeenCalledWith('/login');
 })

--- a/src/components/Card/components/Header/Header.js
+++ b/src/components/Card/components/Header/Header.js
@@ -32,10 +32,12 @@ const Header = (props) => {
         {props.tabData.likeCount > 0 &&
           <span>{props.tabData.likeCount}</span>
         }
-        <FavoriteIconButton 
-          tab_id={props.tabData._id}
-          tabOwner={props.tabData.owner.user}
-        />
+        {props.tabData.isPublic &&
+          <FavoriteIconButton 
+            tab_id={props.tabData._id}
+            tabOwner={props.tabData.owner.user}
+          />
+        }
         <ShareIconButton />
         {props.isOwnedByUser &&
           <EditIconButton tab_id={props.tabData._id}/>

--- a/src/components/Card/components/Header/Header.js
+++ b/src/components/Card/components/Header/Header.js
@@ -29,6 +29,9 @@ const Header = (props) => {
     <Box style={boxStyles}>
       <Typography style={tabNameStyles} >{props.tabData.name}</Typography>
       <Box sx={{display: "inline"}}>
+        {props.tabData.likeCount > 0 &&
+          <span>{props.tabData.likeCount}</span>
+        }
         <FavoriteIconButton 
           tab_id={props.tabData._id}
           tabOwner={props.tabData.owner.user}

--- a/src/components/Card/components/Header/Header.js
+++ b/src/components/Card/components/Header/Header.js
@@ -29,7 +29,10 @@ const Header = (props) => {
     <Box style={boxStyles}>
       <Typography style={tabNameStyles} >{props.tabData.name}</Typography>
       <Box sx={{display: "inline"}}>
-        <FavoriteIconButton isDisabled={props.isOwnedByUser} />
+        <FavoriteIconButton 
+          isDisabled={props.isOwnedByUser} 
+          tab_id={props.tabData._id}
+        />
         <ShareIconButton />
         {props.isOwnedByUser &&
           <EditIconButton tab_id={props.tabData._id}/>

--- a/src/components/Card/components/Header/Header.js
+++ b/src/components/Card/components/Header/Header.js
@@ -30,20 +30,22 @@ const Header = (props) => {
       <Typography style={tabNameStyles} >{props.tabData.name}</Typography>
       <Box sx={{display: "inline"}}>
         <FavoriteIconButton 
-          isDisabled={props.isOwnedByUser} 
           tab_id={props.tabData._id}
+          tabOwner={props.tabData.owner.user}
         />
         <ShareIconButton />
         {props.isOwnedByUser &&
           <EditIconButton tab_id={props.tabData._id}/>
         }
         <ToggledIconButton
+          isDisabled={false}
           iconA={<CloseFullscreenRoundedIcon />}
           titleA={""}
           iconB={<OpenInFullIcon />}
           titleB={"Expand"}
           startOnA={props.isExpanded}
-          handleClick={props.handleExpand}
+          handleClickA={props.handleExpand}
+          handleClickB={props.handleExpand}
         />
       </Box>
     </Box>

--- a/src/components/Card/components/Header/Header.test.js
+++ b/src/components/Card/components/Header/Header.test.js
@@ -1,33 +1,34 @@
 import { render, screen } from "@testing-library/react"
 import { BrowserRouter } from "react-router-dom"
 import Header from './Header'
+import { testTab } from "utils/TestUtils/TestTabObject"
 
-test('header does not render edit button if isOwnedByUser is false', ()=> {
-  render(<Header tabData={{name: 'test'}} user={{username: 'test'}} isOwnedByUser={false} />, {wrapper: BrowserRouter})
+test('does not render edit button if isOwnedByUser is false', ()=> {
+  render(<Header tabData={testTab} user={{username: 'test'}} isOwnedByUser={false} />, {wrapper: BrowserRouter})
   expect(screen.queryByTestId('EditIcon')).not.toBeInTheDocument()
 })
 
-test('header renders like button', ()=> {
-  render(<Header tabData={{name: 'test'}} user={{username: 'test'}} />, {wrapper: BrowserRouter})
-  expect(screen.getByTestId('FavoriteBorderIcon')).toBeInTheDocument()
+test('renders like button', ()=> {
+  render(<Header tabData={testTab} user={{username: 'test'}} />, {wrapper: BrowserRouter})
+  expect(screen.getByTestId('FavoriteIcon')).toBeInTheDocument()
 })
 
-test('header renders share button', ()=> {
-  render(<Header tabData={{name: 'test'}} user={{username: 'test'}} />, {wrapper: BrowserRouter})
+test('renders share button', ()=> {
+  render(<Header tabData={testTab} user={{username: 'test'}} />, {wrapper: BrowserRouter})
   expect(screen.getByTestId('ShareIcon')).toBeInTheDocument()
 })
 
-test('header renders OpenInFullIcon when isExpanded is false', ()=> {
-  render(<Header tabData={{name: 'test'}} user={{username: 'test'}} isExpanded={false} />, {wrapper: BrowserRouter})
+test('renders OpenInFullIcon when isExpanded is false', ()=> {
+  render(<Header tabData={testTab} user={{username: 'test'}} isExpanded={false} />, {wrapper: BrowserRouter})
   expect(screen.getByTestId('OpenInFullIcon')).toBeInTheDocument()
 })
 
-test('header renders edit button if isOwnedByUser is true', ()=> {
-  render(<Header tabData={{name: 'test'}} user={{username: 'test'}} isOwnedByUser={true} />, {wrapper: BrowserRouter})
+test('renders edit button if isOwnedByUser is true', ()=> {
+  render(<Header tabData={testTab} user={{username: 'test'}} isOwnedByUser={true} />, {wrapper: BrowserRouter})
   expect(screen.getByTestId('EditIcon')).toBeInTheDocument()
 })
 
-test('header renders CloseFullscreenRoundedIcon when isExpanded is true', async ()=> {
-  render(<Header tabData={{name: 'test'}} user={{username: 'test'}} isExpanded={true}/>, {wrapper: BrowserRouter})
+test('renders CloseFullscreenRoundedIcon when isExpanded is true', async ()=> {
+  render(<Header tabData={testTab} user={{username: 'test'}} isExpanded={true}/>, {wrapper: BrowserRouter})
   expect(screen.getByTestId('CloseFullscreenRoundedIcon')).toBeInTheDocument()
 })

--- a/src/components/Card/components/Header/Header.test.js
+++ b/src/components/Card/components/Header/Header.test.js
@@ -3,22 +3,22 @@ import { BrowserRouter } from "react-router-dom"
 import Header from './Header'
 
 test('header does not render edit button if isOwnedByUser is false', ()=> {
-  render(<Header tabData={{name: 'test'}} user={{username: 'test'}} isOwnedByUser={false} />)
+  render(<Header tabData={{name: 'test'}} user={{username: 'test'}} isOwnedByUser={false} />, {wrapper: BrowserRouter})
   expect(screen.queryByTestId('EditIcon')).not.toBeInTheDocument()
 })
 
 test('header renders like button', ()=> {
-  render(<Header tabData={{name: 'test'}} user={{username: 'test'}} />)
+  render(<Header tabData={{name: 'test'}} user={{username: 'test'}} />, {wrapper: BrowserRouter})
   expect(screen.getByTestId('FavoriteBorderIcon')).toBeInTheDocument()
 })
 
 test('header renders share button', ()=> {
-  render(<Header tabData={{name: 'test'}} user={{username: 'test'}} />)
+  render(<Header tabData={{name: 'test'}} user={{username: 'test'}} />, {wrapper: BrowserRouter})
   expect(screen.getByTestId('ShareIcon')).toBeInTheDocument()
 })
 
 test('header renders OpenInFullIcon when isExpanded is false', ()=> {
-  render(<Header tabData={{name: 'test'}} user={{username: 'test'}} isExpanded={false} />)
+  render(<Header tabData={{name: 'test'}} user={{username: 'test'}} isExpanded={false} />, {wrapper: BrowserRouter})
   expect(screen.getByTestId('OpenInFullIcon')).toBeInTheDocument()
 })
 
@@ -28,6 +28,6 @@ test('header renders edit button if isOwnedByUser is true', ()=> {
 })
 
 test('header renders CloseFullscreenRoundedIcon when isExpanded is true', async ()=> {
-  render(<Header tabData={{name: 'test'}} user={{username: 'test'}} isExpanded={true}/>)
+  render(<Header tabData={{name: 'test'}} user={{username: 'test'}} isExpanded={true}/>, {wrapper: BrowserRouter})
   expect(screen.getByTestId('CloseFullscreenRoundedIcon')).toBeInTheDocument()
 })

--- a/src/components/Card/components/Header/Header.test.js
+++ b/src/components/Card/components/Header/Header.test.js
@@ -8,7 +8,14 @@ test('does not render edit button if isOwnedByUser is false', ()=> {
   expect(screen.queryByTestId('EditIcon')).not.toBeInTheDocument()
 })
 
-test('renders like button', ()=> {
+test('renders like button on public tabs', ()=> {
+  const tab = testTab
+  tab.isPublic = true
+  render(<Header tabData={tab} user={{username: 'test'}} />, {wrapper: BrowserRouter})
+  expect(screen.getByTestId('FavoriteIcon')).toBeInTheDocument()
+})
+
+test('does not render like button on private tabs', ()=> {
   render(<Header tabData={testTab} user={{username: 'test'}} />, {wrapper: BrowserRouter})
   expect(screen.getByTestId('FavoriteIcon')).toBeInTheDocument()
 })

--- a/src/components/ToggledIconButton/ToggledIconButton.js
+++ b/src/components/ToggledIconButton/ToggledIconButton.js
@@ -1,5 +1,5 @@
 // Components / hooks
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import TooltipIconButton from "components/TooltipIconButton/TooltipIconButton";
 
 const ToggledIconButton = (props) => {
@@ -13,21 +13,34 @@ const ToggledIconButton = (props) => {
   const titleB = props.titleB === undefined ? "" : props.titleB
 
   const handleClick = () => {
-    props.handleClick()
+    if(showIconA) {
+      props.handleClickA()
+    } else {
+      props.handleClickB()
+    }
     setShowIconA(!showIconA)
   }
+
+  useEffect(() => {
+    setShowIconA(props.startOnA === undefined || props.startOnA === true
+      ? true
+      : false
+    )
+  }, [props.startOnA])
 
   return (
     <>
       {showIconA
         ?
           <TooltipIconButton
+            isDisabled={props.isDisabled}
             title={titleA}
             icon={props.iconA}
             onClick={handleClick}
           />
         :
           <TooltipIconButton
+            isDisabled={props.isDisabled}
             title={titleB}
             icon={props.iconB}
             onClick={handleClick}

--- a/src/components/ToggledIconButton/ToggledIconButton.test.js
+++ b/src/components/ToggledIconButton/ToggledIconButton.test.js
@@ -34,10 +34,10 @@ test('switches from iconA to iconB when icon button is clicked', async ()=> {
   render(<ToggledIconButton 
     iconA={<CloseFullscreenRoundedIcon />}
     iconB={<OpenInFullIcon />}
-    handleClick={()=> null}
+    handleClickA={()=> null}
+    handleClickB={()=> null}
   />)
   const user = userEvent.setup()
   await user.click(screen.getByTestId('CloseFullscreenRoundedIcon'))
   expect(screen.getByTestId('OpenInFullIcon')).toBeInTheDocument()
 })
-

--- a/src/components/TooltipIconButton/TooltipIconButton.js
+++ b/src/components/TooltipIconButton/TooltipIconButton.js
@@ -4,7 +4,10 @@ import { IconButton, Tooltip } from "@mui/material";
 const TooltipIconButton = (props) => {
   return (
     <Tooltip title={props.title}>
-      <IconButton onClick={props.onClick}>
+      <IconButton 
+        onClick={props.onClick}
+        disabled={props.isDisabled} 
+      >
         {props.icon}
       </IconButton>
     </Tooltip>

--- a/src/containers/CognitoUserProvider/CognitoUserProvider.js
+++ b/src/containers/CognitoUserProvider/CognitoUserProvider.js
@@ -95,10 +95,10 @@ const CognitoUserProvider = (props) => {
    * Handle changes to user state.
    */
   useEffect(() => {
-    setUserIsLoading(true)
     // If user is not set, check if there is user data in session storage. This allows users to return to the app without having to log back in each time.
     if (!user) {
       const userFromPool = UserPool.getCurrentUser();
+      setUserIsLoading(true)
       setUserIsLoading(false)
       setUser(userFromPool);
     }

--- a/src/containers/CognitoUserProvider/CognitoUserProvider.js
+++ b/src/containers/CognitoUserProvider/CognitoUserProvider.js
@@ -11,7 +11,7 @@ import UserPool from "utils/UserPool";
 const UserContext = createContext({});
 
 const CognitoUserProvider = (props) => {
-  const [user, setUser] = useState(null); // Cognito User object that also holds profile data from MongoDB
+  const [user, setUser] = useState(null)
   const [userIsLoading, setUserIsLoading] = useState(true);
 
   let navigate = useNavigate();
@@ -111,31 +111,34 @@ const CognitoUserProvider = (props) => {
       const userFromPool = UserPool.getCurrentUser();
       const idToken = userUtils.getIdTokenFromUser(userFromPool);
       profileServices
-        .getProfileOfLoggedInUser(userFromPool.username, idToken)
-        .then((response) => {
-          const profile = response.profile;
-          userFromPool["profile"] = profile;
-          const tabsWithOwnerInfo = profile.tablature.map((tab)=> {
-            const owner = {
-              _id: tab._id,
-              preferredUsername: profile.preferredUsername,
-              user: user.username,
-            }
-            tab.owner = owner
-            return tab
-          })
-          userFromPool.profile.tablature = tabsWithOwnerInfo
-          setUserIsLoading(false)
-          setUser(userFromPool);
-        });
+      .getProfileOfLoggedInUser(userFromPool.username, idToken)
+      .then((response) => {
+        const profile = response.profile;
+        userFromPool["profile"] = profile;
+        const tabsWithOwnerInfo = profile.tablature.map((tab)=> {
+          const owner = {
+            _id: tab._id,
+            preferredUsername: profile.preferredUsername,
+            user: user.username,
+          }
+          tab.owner = owner
+          return tab
+        })
+        userFromPool.profile.tablature = tabsWithOwnerInfo
+
+        // set favorite tablature hash
+        const favoriteTabHash = {}
+        profile.favoriteTablature.forEach((tab) => {
+          favoriteTabHash[tab._id] = true
+        })
+        userFromPool.profile.favoriteTabHash = favoriteTabHash
+
+        setUserIsLoading(false)
+        setUser(userFromPool);
+      });
     }
   }, [user]);
-
-  const getCurrentUsersTablature = () => console.log(user)
-  const addToCurrentUsersTablature = (tablature) => {
-    setUser(prev => prev.profile.tablature = [...prev.profile.tablature, tablature])
-  } 
-
+ 
   return (
     <UserContext.Provider
       value={{
@@ -144,8 +147,6 @@ const CognitoUserProvider = (props) => {
         logout,
         user,
         setUser,
-        getCurrentUsersTablature,
-        addToCurrentUsersTablature,
         userIsLoading
       }}
     >

--- a/src/containers/TablatureProvider/TablatureProvider.js
+++ b/src/containers/TablatureProvider/TablatureProvider.js
@@ -8,7 +8,7 @@ import { getIdTokenFromUser } from "utils/userUtils";
 
 const TablatureContext = createContext({});
 
-const UserTablatureProvider = (props) => {
+const TablatureProvider = (props) => {
   const [usersTablature, setUsersTablature] = useState([])
   const [usersLikedTablature, setUsersLikedTablature] = useState({})
   const { user } = useContext(UserContext)
@@ -71,4 +71,4 @@ const UserTablatureProvider = (props) => {
   );
 }
  
-export { UserTablatureProvider, TablatureContext }
+export { TablatureProvider, TablatureContext }

--- a/src/containers/TablatureProvider/TablatureProvider.js
+++ b/src/containers/TablatureProvider/TablatureProvider.js
@@ -27,6 +27,8 @@ const TablatureProvider = (props) => {
     })
   }
 
+  const getTabFromUser =(tab_id) => usersTablature.find((tab) => tab._id === tab_id)
+
   useEffect(() => {
     if(user) {
       const idToken = getIdTokenFromUser(user)
@@ -64,6 +66,7 @@ const TablatureProvider = (props) => {
         usersLikedTablature,
         addToUsersLikedTablature,
         removeFromUsersLikedTablature,
+        getTabFromUser,
       }}
     >
       {props.children}

--- a/src/containers/UserTablatureProvider/UserTablatureProvider.js
+++ b/src/containers/UserTablatureProvider/UserTablatureProvider.js
@@ -1,0 +1,74 @@
+// Components and hooks
+import { createContext, useState, useContext, useEffect } from "react";
+import { UserContext } from "containers/CognitoUserProvider/CognitoUserProvider";
+
+// Services / utils
+import * as profileServices from "services/profileServices";
+import { getIdTokenFromUser } from "utils/userUtils";
+
+const TablatureContext = createContext({});
+
+const UserTablatureProvider = (props) => {
+  const [usersTablature, setUsersTablature] = useState([])
+  const [usersLikedTablature, setUsersLikedTablature] = useState({})
+  const { user } = useContext(UserContext)
+
+  const addToUsersLikedTablature = (tab_id) => {
+    setUsersLikedTablature((prev) => {
+      prev[tab_id] = true
+      return { ...prev }
+    })
+  }
+
+  const removeFromUsersLikedTablature = (tab_id) => {
+    setUsersLikedTablature((prev) => {
+      delete prev[tab_id]
+      return({...prev})
+    })
+  }
+
+  useEffect(() => {
+    if(user) {
+      const idToken = getIdTokenFromUser(user)
+
+      // Get users tablature
+      profileServices
+      .getProfileOfLoggedInUser(user.username, idToken)
+      .then((response) => {
+        const profile = response.profile;
+        const tabsWithOwnerInfo = profile.tablature.map((tab)=> {
+          const owner = {
+            _id: tab._id,
+            preferredUsername: profile.preferredUsername,
+            user: user.username,
+          }
+          tab.owner = owner
+          return tab
+        })
+        setUsersTablature(tabsWithOwnerInfo)
+
+        // get users liked tablature
+        const favoriteTabHash = {}
+        profile.favoriteTablature.forEach((tab) => {
+          favoriteTabHash[tab._id] = true
+        })
+        setUsersLikedTablature(favoriteTabHash)
+      })
+    }
+  }, [user])
+
+  return (
+    <TablatureContext.Provider
+      value={{
+        usersTablature,
+        usersLikedTablature,
+        addToUsersLikedTablature,
+        removeFromUsersLikedTablature,
+      }}
+    >
+      {props.children}
+    </TablatureContext.Provider>
+  );
+}
+ 
+export { UserTablatureProvider, TablatureContext }

--- a/src/pages/Home/components/ContentRoutes/ContentRoutes.test.js
+++ b/src/pages/Home/components/ContentRoutes/ContentRoutes.test.js
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 import {MemoryRouter} from 'react-router-dom'
 import ContentRoutes from './ContentRoutes'
 import { UserContext } from "containers/CognitoUserProvider/CognitoUserProvider";
-
+import { TablatureContext } from "containers/TablatureProvider/TablatureProvider";
 const setTagBarTitle = () => null
 const tags = []
 
@@ -47,16 +47,6 @@ test('/profile/:cognitoUsername renders ProfileContent component', ()=> {
 test('/tablature/:tabId renders TrendingContent component', ()=> {
   renderContentRoutesWithMemoryWrapper(['/tablature/2'])
   expect(screen.getByTestId('TrendingContent')).toBeInTheDocument()
-})
-
-test('/new renders Editor component', ()=> {
-  renderContentRoutesWithMemoryWrapper(['/new'])
-  expect(screen.getByTestId("Editor")).toBeInTheDocument();
-})
-
-test('/edit/:tabId renders Editor component', ()=> {
-  renderContentRoutesWithMemoryWrapper(['/edit/2'])
-  expect(screen.getByTestId("Editor")).toBeInTheDocument();
 })
 
 test('non existing route renders TrendingContent component', ()=> {

--- a/src/pages/Home/components/Editor/Editor.js
+++ b/src/pages/Home/components/Editor/Editor.js
@@ -5,7 +5,7 @@ import { UserContext } from "containers/CognitoUserProvider/CognitoUserProvider"
 
 // MUI
 import Box from '@mui/material/Box';
-import { CircularProgress } from "@mui/material";
+import { CircularProgress, Paper } from "@mui/material";
 
 // Services / utils
 import * as tablatureServices from "services/tablatureServices";
@@ -16,7 +16,6 @@ import Controls from './components/Controls/Controls'
 
 const Editor = (props) => {
   const [showDeleteButton, setShowDeleteButton] = useState(false); // Is the document already in the database?
-  // TODO Rename: isWaitingForResponse
   const [isLoading, setIsLoading] = useState(false); // is the document currently waiting for a response?
   const [tablature, setTablature] = useState({
     isPublic: false,
@@ -175,7 +174,7 @@ const Editor = (props) => {
   return (
     <div data-testid="Editor">
       {isLoading ? ( <CircularProgress /> ) : (
-        <>
+        <Paper>
           <Box sx={{display: 'flex', justifyContent: 'space-between'}}>
             <input
               type="text"
@@ -200,7 +199,7 @@ const Editor = (props) => {
             refreshTablatureObject={refreshTablatureObject}
             deleteBarFromTablature={deleteBarFromTablature}
           />
-        </>
+        </Paper>
       )}
     </div>
   );

--- a/src/pages/Home/components/Editor/Editor.js
+++ b/src/pages/Home/components/Editor/Editor.js
@@ -2,7 +2,7 @@
 import { useState, useContext, useEffect, useCallback } from 'react'
 import { useNavigate, useParams } from "react-router-dom";
 import { UserContext } from "containers/CognitoUserProvider/CognitoUserProvider";
-
+import { TablatureContext } from "containers/TablatureProvider/TablatureProvider";
 // MUI
 import Box from '@mui/material/Box';
 import { CircularProgress, Paper } from "@mui/material";
@@ -24,8 +24,10 @@ const Editor = (props) => {
     tags: [],
     isBassTab: false,
   });
-   const { user } = useContext(UserContext);
+  
+  const { user } = useContext(UserContext);
   const { tabId } = useParams();
+  const { getTabFromUser } = useContext(TablatureContext)
   let navigate = useNavigate();
   
   const deleteTablatureFromDatabase = () => {
@@ -144,17 +146,14 @@ const Editor = (props) => {
 
   useEffect(() => {
     if (tabId) {
-      setIsLoading(true)
-      tablatureServices.getTablatureById(tabId).then((res) => {
-        if (res["error"]) {
-          // TODO Navigate back to where the user came from
-          navigate(`/trending`);
-        }
-        setTablature(res.tablature);
-        setIsLoading(false)
-      });
+      const tab = getTabFromUser(tabId)
+      if(tab) {
+        setTablature(getTabFromUser(tabId));
+      } else {
+        navigate('/trending')
+      }
     }
-  }, [tabId, navigate]);
+  }, [tabId, getTabFromUser, navigate]);
   
   useEffect(() => {
     if (user) {

--- a/src/pages/Home/components/ProfileContent/ProfileContent.js
+++ b/src/pages/Home/components/ProfileContent/ProfileContent.js
@@ -2,7 +2,9 @@
 import { useEffect, useState, useContext } from "react";
 import { useParams } from "react-router-dom";
 import { UserContext } from "containers/CognitoUserProvider/CognitoUserProvider";
+import { TablatureContext } from "containers/TablatureProvider/TablatureProvider";
 import CardGrid from "components/CardGrid/CardGrid";
+
 
 // Services
 import * as profileServices from "services/profileServices";
@@ -14,12 +16,13 @@ const ProfileContent = () => {
   const [tablature, setTablature] = useState(null);
   const { cognitoUsername } = useParams();
   const { user, userIsLoading } = useContext(UserContext);
+  const { usersTablature } = useContext(TablatureContext);
 
   useEffect(() => {
     let subscribed = true
     if(!userIsLoading && cognitoUsername) {
-      if (user.profile && user.username === cognitoUsername) {
-        setTablature(user.profile.tablature)
+      if (user.username === cognitoUsername) {
+        setTablature(usersTablature)
       } else {
         profileServices.getUsersPublicInfo(cognitoUsername)
         .then((res) => {
@@ -33,11 +36,10 @@ const ProfileContent = () => {
         })
       }
     }
-
     return () => {
       subscribed = false
     }
-  }, [cognitoUsername, user, userIsLoading]);
+  }, [cognitoUsername, user, userIsLoading, usersTablature]);
 
   return (
     <div data-testid="ProfileContent">

--- a/src/pages/Home/components/Sidebar/__snapshots__/Sidebar.test.js.snap
+++ b/src/pages/Home/components/Sidebar/__snapshots__/Sidebar.test.js.snap
@@ -9,7 +9,7 @@ exports[`renders correctly 1`] = `
     className="css-1qb7z1w-MuiStack-root"
   >
     <button
-      className="MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation MuiButtonBase-root  css-6dozrm-MuiButtonBase-root-MuiButton-root"
+      className="MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation MuiButtonBase-root  css-13sqc32-MuiButtonBase-root-MuiButton-root"
       disabled={false}
       onBlur={[Function]}
       onClick={[Function]}
@@ -81,7 +81,7 @@ exports[`renders correctly 1`] = `
       Trending
     </button>
     <button
-      className="MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation MuiButtonBase-root  css-13sqc32-MuiButtonBase-root-MuiButton-root"
+      className="MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation MuiButtonBase-root  css-6dozrm-MuiButtonBase-root-MuiButton-root"
       disabled={false}
       onBlur={[Function]}
       onClick={[Function]}

--- a/src/pages/Home/components/Sidebar/components/CollectionButton/CollectionButton.js
+++ b/src/pages/Home/components/Sidebar/components/CollectionButton/CollectionButton.js
@@ -31,7 +31,7 @@ const CollectionButton = () => {
     <Button 
       startIcon={<FavoriteIcon />}
       onClick={handleClick}
-      sx={{justifyContent: 'left', pl: '16px'}}
+      sx={{justifyContent: 'left', pl: '16px', my: 1}}
       disableElevation
       variant={variant}
     >

--- a/src/pages/Home/components/Sidebar/components/CollectionButton/__snapshots__/CollectionButton.test.js.snap
+++ b/src/pages/Home/components/Sidebar/components/CollectionButton/__snapshots__/CollectionButton.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`variant is "contained" when viewing owned collection 1`] = `
 <button
-  className="MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButtonBase-root  css-l5i4be-MuiButtonBase-root-MuiButton-root"
+  className="MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButtonBase-root  css-13twu6j-MuiButtonBase-root-MuiButton-root"
   disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
@@ -44,7 +44,7 @@ exports[`variant is "contained" when viewing owned collection 1`] = `
 
 exports[`variant is "text" when not at the collections route 1`] = `
 <button
-  className="MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation MuiButtonBase-root  css-13sqc32-MuiButtonBase-root-MuiButton-root"
+  className="MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation MuiButtonBase-root  css-6dozrm-MuiButtonBase-root-MuiButton-root"
   disabled={false}
   onBlur={[Function]}
   onClick={[Function]}

--- a/src/pages/Home/components/Sidebar/components/LatestButton/LatestButton.js
+++ b/src/pages/Home/components/Sidebar/components/LatestButton/LatestButton.js
@@ -24,7 +24,7 @@ const LatestButton = () => {
     <Button 
       startIcon={<StarsIcon />}
       onClick={handleClick}
-      sx={{justifyContent: 'left', pl: '16px', my: 1}}
+      sx={{justifyContent: 'left', pl: '16px'}}
       disableElevation
       variant={variant}
     >

--- a/src/pages/Home/components/Sidebar/components/LatestButton/__snapshots__/LatestButton.test.js.snap
+++ b/src/pages/Home/components/Sidebar/components/LatestButton/__snapshots__/LatestButton.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`variant changes to "contained" when viewing latest 1`] = `
 <button
-  className="MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButtonBase-root  css-13twu6j-MuiButtonBase-root-MuiButton-root"
+  className="MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButtonBase-root  css-l5i4be-MuiButtonBase-root-MuiButton-root"
   disabled={false}
   onBlur={[Function]}
   onClick={[Function]}
@@ -44,7 +44,7 @@ exports[`variant changes to "contained" when viewing latest 1`] = `
 
 exports[`variant is "text" when not viewing latest 1`] = `
 <button
-  className="MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation MuiButtonBase-root  css-6dozrm-MuiButtonBase-root-MuiButton-root"
+  className="MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation MuiButtonBase-root  css-13sqc32-MuiButtonBase-root-MuiButton-root"
   disabled={false}
   onBlur={[Function]}
   onClick={[Function]}

--- a/src/services/profileServices.js
+++ b/src/services/profileServices.js
@@ -52,4 +52,22 @@ const getUsersPublicInfo = async (username) => {
   return response.json();
 };
 
-export { create, getUsersPublicInfo, getProfileOfLoggedInUser };
+const handleLikingTablature = async (action,profile_id, likedTablature_id, idToken) => { 
+  const payload = {
+    profile_id,
+    likedTablature_id,
+    action
+  }
+
+  const response = await fetch(`${BASE_URL}/profile/like`, {
+    method: "PATCH",
+    headers: {
+      Authorization: idToken,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  });
+  return response.json();
+}
+
+export { create, getUsersPublicInfo, getProfileOfLoggedInUser, handleLikingTablature };


### PR DESCRIPTION
This PR focuses on implementing the like feature. Additional optimizations are included since they piggyback off the code built to implement the like feature.

### Liking tabs
- Users can like tabs. Liking a tab will replace the outline heart with a filled in heart
- Like count is shown on the Card
- Like button disabled for private tabs
- Liked tabs are stored on the users profile and will persist through logouts / refreshes.
- A new TablatureContext container component was created. The purpose of this context is to store all of the tablature that has been loaded into the front end. This was needed for the front end to know what tabs a user liked, and which 'like' icon button should be shown, but there are many optimization benefits that will stem from this.

### load time optimizations
Previously, user tabs were held in the user context. This was easy since many of the files already imported user, but it didn't make sense in regards to separation of concerns and single purpose components. So I built the TablatureContext to house all of that data. The benefit is we can store all tablature data that is loaded from the back end and dump it into this context, avoiding repeated API calls. 

For example, one performance update I implemented was with the profile route. It used to hit the backend for all profiles including the current users, even though the current users tab data was already in state. Now, the current users profile will pull data that was preloaded from the tablature context. Clicking "Collections" button instantly loads the users collection as a result. (For some reason there is a slight delay in pulling profile data when clicking the current users name on a card, even though it isn't hitting the backend.)

Fetch requests were eliminated for Editing a tab, and it now loads instantly since -again- the tab was pre-loaded into the tablature context.