### PR TITLE
 Theme adjustments: Sidebar + Prettier Config

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,10 +5,10 @@ name: Riffin CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
-    
+    branches: ["main"]
+
 env:
   REACT_APP_COGNITO_USER_POOL_ID: TEST_APP_COGNITO_USER_POOL
   REACT_APP_COGNITO_CLIENT_ID: TEST_APP_COGNITO_CLIENT_ID
@@ -16,7 +16,6 @@ env:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     strategy:
@@ -25,12 +24,12 @@ jobs:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
-      with:
-        node-version: ${{ matrix.node-version }}
-        cache: 'npm'
-    - run: npm ci
-    - run: npm run build --if-present
-    - run: npm test
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "npm"
+      - run: npm ci
+      - run: npm run build --if-present
+      - run: npm test

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,4 +1,3 @@
-
 {
   "compilerOptions": {
     "baseUrl": "src"

--- a/src/App.js
+++ b/src/App.js
@@ -6,7 +6,7 @@ import { CssBaseline } from "@mui/material";
 // import Button from "@mui/material/Button";
 
 import { CognitoUserProvider } from "containers/CognitoUserProvider/CognitoUserProvider";
-import { TablatureProvider } from "containers/TablatureProvider/TablatureProvider"
+import { TablatureProvider } from "containers/TablatureProvider/TablatureProvider";
 import Home from "pages/Home/Home";
 
 function App() {

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,13 +1,13 @@
 import { render, screen } from "@testing-library/react";
-import React from 'react'
+import React from "react";
 
-import  App from './App';
-import {BrowserRouter} from 'react-router-dom'
+import App from "./App";
+import { BrowserRouter } from "react-router-dom";
 
-test('App renders the Home component on initialization', ()=> {
-  render(<App />, {wrapper: BrowserRouter})
-  expect(screen.getByTestId('Home')).toBeInTheDocument()
-})
+test("App renders the Home component on initialization", () => {
+  render(<App />, { wrapper: BrowserRouter });
+  expect(screen.getByTestId("Home")).toBeInTheDocument();
+});
 
 // test('App redirects non users to the login page when navigating to a /profile route', async ()=> {
 //   render(<App />, {wrapper: BrowserRouter})

--- a/src/Theme.js
+++ b/src/Theme.js
@@ -1,14 +1,6 @@
 import { createTheme } from "@mui/material/styles";
 
 const darkTheme = createTheme({
-  breakpoints: {
-    values: {
-      mobile: 0,
-      tablet: 640,
-      laptop: 1024,
-      desktop: 1200,
-    },
-  },
   palette: {
     mode: "dark",
     background: {

--- a/src/Theme.js
+++ b/src/Theme.js
@@ -1,6 +1,14 @@
 import { createTheme } from "@mui/material/styles";
 
 const darkTheme = createTheme({
+  breakpoints: {
+    values: {
+      mobile: 0,
+      tablet: 640,
+      laptop: 1024,
+      desktop: 1200,
+    },
+  },
   palette: {
     mode: "dark",
     background: {
@@ -24,9 +32,9 @@ const darkTheme = createTheme({
       styleOverrides: {
         root: {
           // background: "transparent",
-        }
-      }
-    }
+        },
+      },
+    },
   },
   typography: {
     // Main Header

--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -14,8 +14,8 @@ const Card = (props) => {
 
   const contentBoxStyles = {
     display: "flex",
-    justifyContent: "center"
-  }
+    justifyContent: "center",
+  };
 
   const cardStyles = {
     padding: "15px",
@@ -30,7 +30,11 @@ const Card = (props) => {
         handleExpand={props.handleExpand}
       />
       <Box style={contentBoxStyles}>
-        <Content tablatureBlocks={props.tabData.blocks} isExpanded={props.isExpanded} numberOfStrings={props.tabData.numberOfStrings}/>
+        <Content
+          tablatureBlocks={props.tabData.blocks}
+          isExpanded={props.isExpanded}
+          numberOfStrings={props.tabData.numberOfStrings}
+        />
       </Box>
       <Footer
         preferredUsername={props.tabData.owner.preferredUsername}

--- a/src/components/Card/Card.test.js
+++ b/src/components/Card/Card.test.js
@@ -1,27 +1,33 @@
-import { render, screen } from "@testing-library/react"
+import { render, screen } from "@testing-library/react";
 import { BrowserRouter } from "react-router-dom";
 import { testTab } from "utils/TestUtils/TestTabObject";
-import Card from './Card';
+import Card from "./Card";
 
-test('isExpanded false shows only the first bar', async ()=> {
-  render(<Card 
-    tabData={testTab} 
-    user={{username: 'JarJar_Binks'}} 
-    handleExpand={() => null}
-    isExpanded={false}
-  />, {wrapper: BrowserRouter})
+test("isExpanded false shows only the first bar", async () => {
+  render(
+    <Card
+      tabData={testTab}
+      user={{ username: "JarJar_Binks" }}
+      handleExpand={() => null}
+      isExpanded={false}
+    />,
+    { wrapper: BrowserRouter }
+  );
 
-  expect(screen.getByText('test inputs A')).toBeInTheDocument()
-  expect(screen.queryByText('test inputs B')).not.toBeInTheDocument()
-})
+  expect(screen.getByText("test inputs A")).toBeInTheDocument();
+  expect(screen.queryByText("test inputs B")).not.toBeInTheDocument();
+});
 
-test('isExpanded true shows additional bars', async ()=> {
-  render(<Card 
-    tabData={testTab} 
-    user={{username: 'JarJar_Binks'}} 
-    handleExpand={() => null}
-    isExpanded={true}
-  />, {wrapper: BrowserRouter})
-  expect(screen.getByText('test inputs A')).toBeInTheDocument()
-  expect(screen.getByText('test inputs B')).toBeInTheDocument()
-})
+test("isExpanded true shows additional bars", async () => {
+  render(
+    <Card
+      tabData={testTab}
+      user={{ username: "JarJar_Binks" }}
+      handleExpand={() => null}
+      isExpanded={true}
+    />,
+    { wrapper: BrowserRouter }
+  );
+  expect(screen.getByText("test inputs A")).toBeInTheDocument();
+  expect(screen.getByText("test inputs B")).toBeInTheDocument();
+});

--- a/src/components/Card/components/Content/Content.js
+++ b/src/components/Card/components/Content/Content.js
@@ -12,29 +12,29 @@ const boxStyles = {
   margin: "10px 0",
   width: "100%",
   textAlign: "center",
-}
+};
 
 const Content = (props) => {
   return (
     <Box style={boxStyles}>
-      {props.isExpanded ? 
-        (
-          <div style={scrollWrapper}>
-            {props.tablatureBlocks.map((block, i) => (
-              <div key={i}>
-                <Typography>{block.label}</Typography>
-                <TablatureBlock 
-                  numberOfStrings={props.numberOfStrings} 
-                  blockData={block} 
-                />
-              </div>
-            ))}
-          </div>
-        ) : (<TablatureBlock 
-              blockData={props.tablatureBlocks[0]} 
-              numberOfStrings={props.numberOfStrings}
-            />)
-      }
+      {props.isExpanded ? (
+        <div style={scrollWrapper}>
+          {props.tablatureBlocks.map((block, i) => (
+            <div key={i}>
+              <Typography>{block.label}</Typography>
+              <TablatureBlock
+                numberOfStrings={props.numberOfStrings}
+                blockData={block}
+              />
+            </div>
+          ))}
+        </div>
+      ) : (
+        <TablatureBlock
+          blockData={props.tablatureBlocks[0]}
+          numberOfStrings={props.numberOfStrings}
+        />
+      )}
     </Box>
   );
 };

--- a/src/components/Card/components/Content/Content.test.js
+++ b/src/components/Card/components/Content/Content.test.js
@@ -1,31 +1,31 @@
-import { render, screen } from '@testing-library/react'
-import Content from './Content'
+import { render, screen } from "@testing-library/react";
+import Content from "./Content";
 const testBlocks = [
   {
-    label: 'test bar A',
-    inputs: 'test inputs A',
-    dashes: 'test dashes A',
+    label: "test bar A",
+    inputs: "test inputs A",
+    dashes: "test dashes A",
   },
   {
-    label: 'test bar B',
-    inputs: 'test inputs B',
-    dashes: 'test dashes B',
-  }
-]
+    label: "test bar B",
+    inputs: "test inputs B",
+    dashes: "test dashes B",
+  },
+];
 
-test('card renders a single block when not expanded', ()=> {
-  render(<Content tablatureBlocks={testBlocks} isExpanded={false} />)
-  expect(screen.getByText('test inputs A')).toBeInTheDocument()
-  expect(screen.queryByText('test dashes B')).not.toBeInTheDocument()
-})
+test("card renders a single block when not expanded", () => {
+  render(<Content tablatureBlocks={testBlocks} isExpanded={false} />);
+  expect(screen.getByText("test inputs A")).toBeInTheDocument();
+  expect(screen.queryByText("test dashes B")).not.toBeInTheDocument();
+});
 
-test('card renders all blocks when expanded and more than one bar exists', ()=>{
-  render(<Content tablatureBlocks={testBlocks} isExpanded={true} />)
-  expect(screen.getByText('test inputs A')).toBeInTheDocument()
-  expect(screen.getByText('test inputs B')).toBeInTheDocument()
-})
-test('card renders bar labels when expanded', ()=> {
-  render(<Content tablatureBlocks={testBlocks} isExpanded={true} />)
-  expect(screen.getByText('test bar A')).toBeInTheDocument()
-  expect(screen.getByText('test bar B')).toBeInTheDocument()
-})
+test("card renders all blocks when expanded and more than one bar exists", () => {
+  render(<Content tablatureBlocks={testBlocks} isExpanded={true} />);
+  expect(screen.getByText("test inputs A")).toBeInTheDocument();
+  expect(screen.getByText("test inputs B")).toBeInTheDocument();
+});
+test("card renders bar labels when expanded", () => {
+  render(<Content tablatureBlocks={testBlocks} isExpanded={true} />);
+  expect(screen.getByText("test bar A")).toBeInTheDocument();
+  expect(screen.getByText("test bar B")).toBeInTheDocument();
+});

--- a/src/components/Card/components/EditIconButton/EditIconButton.js
+++ b/src/components/Card/components/EditIconButton/EditIconButton.js
@@ -2,19 +2,19 @@
 import { useNavigate } from "react-router-dom";
 import TooltipIconButton from "components/TooltipIconButton/TooltipIconButton";
 // MUI
-import EditIcon from '@mui/icons-material/Edit';
+import EditIcon from "@mui/icons-material/Edit";
 
 const EditButtonIcon = (props) => {
-  const navigate = useNavigate()
-  const handleClick = () => navigate(`/edit/${props.tab_id}`)
+  const navigate = useNavigate();
+  const handleClick = () => navigate(`/edit/${props.tab_id}`);
 
   return (
-    <TooltipIconButton 
-      icon={ <EditIcon />}
+    <TooltipIconButton
+      icon={<EditIcon />}
       title={"Edit"}
       onClick={handleClick}
     />
   );
-}
- 
+};
+
 export default EditButtonIcon;

--- a/src/components/Card/components/EditIconButton/EditIconButton.test.js
+++ b/src/components/Card/components/EditIconButton/EditIconButton.test.js
@@ -1,17 +1,17 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import EditButtonIcon from './EditIconButton';
+import EditButtonIcon from "./EditIconButton";
 
 const mockedNavigate = jest.fn();
 
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useNavigate: () => mockedNavigate
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: () => mockedNavigate,
 }));
 
-test('clicking the edit button navigates to the edit component', async ()=> {
-  render(<EditButtonIcon tab_id={2} />)
-  const user = userEvent.setup()
-  await user.click(screen.getByLabelText('Edit'))
-  expect(mockedNavigate).toHaveBeenCalledWith('/edit/2');
-})
+test("clicking the edit button navigates to the edit component", async () => {
+  render(<EditButtonIcon tab_id={2} />);
+  const user = userEvent.setup();
+  await user.click(screen.getByLabelText("Edit"));
+  expect(mockedNavigate).toHaveBeenCalledWith("/edit/2");
+});

--- a/src/components/Card/components/FavoriteIconButton/FavoriteIconButton.js
+++ b/src/components/Card/components/FavoriteIconButton/FavoriteIconButton.js
@@ -6,42 +6,45 @@ import { useNavigate } from "react-router-dom";
 
 // Services / Utils
 import { getIdTokenFromUser } from "utils/userUtils";
-import { handleLikingTablature } from 'services/profileServices'
+import { handleLikingTablature } from "services/profileServices";
 
 // MUI
 import FavoriteBorderIcon from "@mui/icons-material/FavoriteBorder";
-import FavoriteIcon from '@mui/icons-material/Favorite';
+import FavoriteIcon from "@mui/icons-material/Favorite";
 import ToggledIconButton from "components/ToggledIconButton/ToggledIconButton";
 
 const FavoriteIconButton = (props) => {
-  const navigate = useNavigate()
-  const { user } = useContext(UserContext)
-  const { addToUsersLikedTablature, removeFromUsersLikedTablature } = useContext(TablatureContext)
-  const [likedByCurrentUser, setLikedByCurrentUser] = useState()
-  const [ownedByUser, setOwnedByUser] = useState()
+  const navigate = useNavigate();
+  const { user } = useContext(UserContext);
+  const { addToUsersLikedTablature, removeFromUsersLikedTablature } =
+    useContext(TablatureContext);
+  const [likedByCurrentUser, setLikedByCurrentUser] = useState();
+  const [ownedByUser, setOwnedByUser] = useState();
 
   const handleClick = (action) => {
-    if(user) {
-      if(action === 'like') {
-        addToUsersLikedTablature(props.tab_id)  
+    if (user) {
+      if (action === "like") {
+        addToUsersLikedTablature(props.tab_id);
       } else {
-        removeFromUsersLikedTablature(props.tab_id)
+        removeFromUsersLikedTablature(props.tab_id);
       }
       const idToken = getIdTokenFromUser(user);
-      handleLikingTablature(action, user.profile._id, props.tab_id, idToken)
-      setLikedByCurrentUser(!likedByCurrentUser)
+      handleLikingTablature(action, user.profile._id, props.tab_id, idToken);
+      setLikedByCurrentUser(!likedByCurrentUser);
     } else {
-      navigate("/login")
+      navigate("/login");
     }
-  }
+  };
 
   useEffect(() => {
-    if(user) {
-      const likeStatus = user.profile?.favoriteTabHash[props.tab_id] ? true : false
-      setLikedByCurrentUser(likeStatus)
-      setOwnedByUser(user.username === props.tabOwner)
+    if (user) {
+      const likeStatus = user.profile?.favoriteTabHash[props.tab_id]
+        ? true
+        : false;
+      setLikedByCurrentUser(likeStatus);
+      setOwnedByUser(user.username === props.tabOwner);
     }
-  }, [user, props])
+  }, [user, props]);
 
   return (
     <>
@@ -50,13 +53,13 @@ const FavoriteIconButton = (props) => {
         startOnA={likedByCurrentUser}
         iconA={<FavoriteIcon />}
         titleA={""}
-        handleClickA={() => handleClick('unlike')}
+        handleClickA={() => handleClick("unlike")}
         iconB={<FavoriteBorderIcon />}
         titleB={""}
-        handleClickB={() => handleClick('like')}
+        handleClickB={() => handleClick("like")}
       />
     </>
   );
-}
- 
+};
+
 export default FavoriteIconButton;

--- a/src/components/Card/components/FavoriteIconButton/FavoriteIconButton.test.js
+++ b/src/components/Card/components/FavoriteIconButton/FavoriteIconButton.test.js
@@ -3,16 +3,16 @@ import FavoriteIconButton from "./FavoriteIconButton";
 import userEvent from "@testing-library/user-event";
 import { BrowserRouter } from "react-router-dom";
 
-const mockedNavigate = jest.fn()
+const mockedNavigate = jest.fn();
 
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useNavigate: () => mockedNavigate
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: () => mockedNavigate,
 }));
 
-test('navigates non users to login when clicked', async ()=> {
-  render(<FavoriteIconButton isDisabled={false}/>, {wrapper: BrowserRouter})
-  const user = userEvent.setup()
-  await user.click(screen.getByRole('button'))
-  expect(mockedNavigate).toHaveBeenCalledWith('/login');
-})
+test("navigates non users to login when clicked", async () => {
+  render(<FavoriteIconButton isDisabled={false} />, { wrapper: BrowserRouter });
+  const user = userEvent.setup();
+  await user.click(screen.getByRole("button"));
+  expect(mockedNavigate).toHaveBeenCalledWith("/login");
+});

--- a/src/components/Card/components/Footer/Footer.js
+++ b/src/components/Card/components/Footer/Footer.js
@@ -4,48 +4,44 @@ import { Avatar, Box, Link, Chip } from "@mui/material";
 const wrapperBoxStyles = {
   display: "flex",
   justifyContent: "space-between",
-}
+};
 
 const tagBoxStyles = {
   display: "flex",
   width: "50%",
   alignItems: "end",
   overflow: "hidden",
-}
+};
 
 const userBoxStyles = {
   display: "flex",
   width: "50%",
-  justifyContent: "end"
-}
+  justifyContent: "end",
+};
 
 const userLinkStyles = {
   alignSelf: "end",
-  marginRight: "12px"
-}
+  marginRight: "12px",
+};
 
 const Footer = (props) => {
   return (
     <Box style={wrapperBoxStyles}>
-        <Box style={tagBoxStyles}>
-          {props.tags.map((tag, i) =>(
-            <Chip 
-              key={i}
-              label={tag} 
-              size="small" 
-            />
-          ))}
-        </Box>
-        <Box style={userBoxStyles}>
-          <Link 
-            underline="hover"
-            style={userLinkStyles} 
-            href={`/profile/${props.user}`}
-          >
-            by {props.preferredUsername}
-          </Link>
-          <Avatar />
-        </Box>
+      <Box style={tagBoxStyles}>
+        {props.tags.map((tag, i) => (
+          <Chip key={i} label={tag} size="small" />
+        ))}
+      </Box>
+      <Box style={userBoxStyles}>
+        <Link
+          underline="hover"
+          style={userLinkStyles}
+          href={`/profile/${props.user}`}
+        >
+          by {props.preferredUsername}
+        </Link>
+        <Avatar />
+      </Box>
     </Box>
   );
 };

--- a/src/components/Card/components/Footer/Footer.test.js
+++ b/src/components/Card/components/Footer/Footer.test.js
@@ -1,17 +1,17 @@
-import { render, screen } from "@testing-library/react"
-import Footer from "./Footer"
+import { render, screen } from "@testing-library/react";
+import Footer from "./Footer";
 
 // Write this test once tags are implemented
-test('footer renders tags', ()=> {
-  const testTags =['testTag - A', 'testTag - B']
-  render(<Footer tags={testTags} />)
-  expect(screen.getByText('testTag - A')).toBeInTheDocument()
-  expect(screen.getByText('testTag - B')).toBeInTheDocument()
-})
+test("footer renders tags", () => {
+  const testTags = ["testTag - A", "testTag - B"];
+  render(<Footer tags={testTags} />);
+  expect(screen.getByText("testTag - A")).toBeInTheDocument();
+  expect(screen.getByText("testTag - B")).toBeInTheDocument();
+});
 
-test('card renders preferredUsername', ()=> {
-  render(<Footer tags={[]} preferredUsername={'JarJar_Binks'} />)
-  expect(screen.getByText('by JarJar_Binks')).toBeInTheDocument()
-})
+test("card renders preferredUsername", () => {
+  render(<Footer tags={[]} preferredUsername={"JarJar_Binks"} />);
+  expect(screen.getByText("by JarJar_Binks")).toBeInTheDocument();
+});
 
-test.todo('clicking preferredUsername routes to profile content')
+test.todo("clicking preferredUsername routes to profile content");

--- a/src/components/Card/components/Header/Header.js
+++ b/src/components/Card/components/Header/Header.js
@@ -12,36 +12,32 @@ import CloseFullscreenRoundedIcon from "@mui/icons-material/CloseFullscreenRound
 const boxStyles = {
   display: "flex",
   justifyContent: "space-between",
-  marginBottom: "5px"
-}
+  marginBottom: "5px",
+};
 
-const tabNameStyles ={
+const tabNameStyles = {
   overflow: "hidden",
   whiteSpace: "nowrap",
   textOverflow: "ellipsis",
-  display: "inline", 
+  display: "inline",
   alignSelf: "center",
   width: "50%",
-}
+};
 
 const Header = (props) => {
   return (
     <Box style={boxStyles}>
-      <Typography style={tabNameStyles} >{props.tabData.name}</Typography>
-      <Box sx={{display: "inline"}}>
-        {props.tabData.likeCount > 0 &&
-          <span>{props.tabData.likeCount}</span>
-        }
-        {props.tabData.isPublic &&
-          <FavoriteIconButton 
+      <Typography style={tabNameStyles}>{props.tabData.name}</Typography>
+      <Box sx={{ display: "inline" }}>
+        {props.tabData.likeCount > 0 && <span>{props.tabData.likeCount}</span>}
+        {props.tabData.isPublic && (
+          <FavoriteIconButton
             tab_id={props.tabData._id}
             tabOwner={props.tabData.owner.user}
           />
-        }
+        )}
         <ShareIconButton />
-        {props.isOwnedByUser &&
-          <EditIconButton tab_id={props.tabData._id}/>
-        }
+        {props.isOwnedByUser && <EditIconButton tab_id={props.tabData._id} />}
         <ToggledIconButton
           isDisabled={false}
           iconA={<CloseFullscreenRoundedIcon />}

--- a/src/components/Card/components/Header/Header.js
+++ b/src/components/Card/components/Header/Header.js
@@ -29,7 +29,8 @@ const Header = (props) => {
     <Box style={boxStyles}>
       <Typography style={tabNameStyles}>{props.tabData.name}</Typography>
       <Box sx={{ display: "inline" }}>
-        {props.tabData.likeCount > 0 && <span>{props.tabData.likeCount}</span>}
+        {props.tabData.likeCount > 0 && 
+        <span>{props.tabData.likeCount}</span>}
         {props.tabData.isPublic && (
           <FavoriteIconButton
             tab_id={props.tabData._id}

--- a/src/components/Card/components/Header/Header.test.js
+++ b/src/components/Card/components/Header/Header.test.js
@@ -1,41 +1,67 @@
-import { render, screen } from "@testing-library/react"
-import { BrowserRouter } from "react-router-dom"
-import Header from './Header'
-import { testTab } from "utils/TestUtils/TestTabObject"
+import { render, screen } from "@testing-library/react";
+import { BrowserRouter } from "react-router-dom";
+import Header from "./Header";
+import { testTab } from "utils/TestUtils/TestTabObject";
 
-test('does not render edit button if isOwnedByUser is false', ()=> {
-  render(<Header tabData={testTab} user={{username: 'test'}} isOwnedByUser={false} />, {wrapper: BrowserRouter})
-  expect(screen.queryByTestId('EditIcon')).not.toBeInTheDocument()
-})
+test("does not render edit button if isOwnedByUser is false", () => {
+  render(
+    <Header
+      tabData={testTab}
+      user={{ username: "test" }}
+      isOwnedByUser={false}
+    />,
+    { wrapper: BrowserRouter }
+  );
+  expect(screen.queryByTestId("EditIcon")).not.toBeInTheDocument();
+});
 
-test('renders like button on public tabs', ()=> {
-  const tab = testTab
-  tab.isPublic = true
-  render(<Header tabData={tab} user={{username: 'test'}} />, {wrapper: BrowserRouter})
-  expect(screen.getByTestId('FavoriteIcon')).toBeInTheDocument()
-})
+test("renders like button on public tabs", () => {
+  const tab = testTab;
+  tab.isPublic = true;
+  render(<Header tabData={tab} user={{ username: "test" }} />, {
+    wrapper: BrowserRouter,
+  });
+  expect(screen.getByTestId("FavoriteIcon")).toBeInTheDocument();
+});
 
-test('does not render like button on private tabs', ()=> {
-  render(<Header tabData={testTab} user={{username: 'test'}} />, {wrapper: BrowserRouter})
-  expect(screen.getByTestId('FavoriteIcon')).toBeInTheDocument()
-})
+test("does not render like button on private tabs", () => {
+  render(<Header tabData={testTab} user={{ username: "test" }} />, {
+    wrapper: BrowserRouter,
+  });
+  expect(screen.getByTestId("FavoriteIcon")).toBeInTheDocument();
+});
 
-test('renders share button', ()=> {
-  render(<Header tabData={testTab} user={{username: 'test'}} />, {wrapper: BrowserRouter})
-  expect(screen.getByTestId('ShareIcon')).toBeInTheDocument()
-})
+test("renders share button", () => {
+  render(<Header tabData={testTab} user={{ username: "test" }} />, {
+    wrapper: BrowserRouter,
+  });
+  expect(screen.getByTestId("ShareIcon")).toBeInTheDocument();
+});
 
-test('renders OpenInFullIcon when isExpanded is false', ()=> {
-  render(<Header tabData={testTab} user={{username: 'test'}} isExpanded={false} />, {wrapper: BrowserRouter})
-  expect(screen.getByTestId('OpenInFullIcon')).toBeInTheDocument()
-})
+test("renders OpenInFullIcon when isExpanded is false", () => {
+  render(
+    <Header tabData={testTab} user={{ username: "test" }} isExpanded={false} />,
+    { wrapper: BrowserRouter }
+  );
+  expect(screen.getByTestId("OpenInFullIcon")).toBeInTheDocument();
+});
 
-test('renders edit button if isOwnedByUser is true', ()=> {
-  render(<Header tabData={testTab} user={{username: 'test'}} isOwnedByUser={true} />, {wrapper: BrowserRouter})
-  expect(screen.getByTestId('EditIcon')).toBeInTheDocument()
-})
+test("renders edit button if isOwnedByUser is true", () => {
+  render(
+    <Header
+      tabData={testTab}
+      user={{ username: "test" }}
+      isOwnedByUser={true}
+    />,
+    { wrapper: BrowserRouter }
+  );
+  expect(screen.getByTestId("EditIcon")).toBeInTheDocument();
+});
 
-test('renders CloseFullscreenRoundedIcon when isExpanded is true', async ()=> {
-  render(<Header tabData={testTab} user={{username: 'test'}} isExpanded={true}/>, {wrapper: BrowserRouter})
-  expect(screen.getByTestId('CloseFullscreenRoundedIcon')).toBeInTheDocument()
-})
+test("renders CloseFullscreenRoundedIcon when isExpanded is true", async () => {
+  render(
+    <Header tabData={testTab} user={{ username: "test" }} isExpanded={true} />,
+    { wrapper: BrowserRouter }
+  );
+  expect(screen.getByTestId("CloseFullscreenRoundedIcon")).toBeInTheDocument();
+});

--- a/src/components/Card/components/ShareIconButton/ShareIconButton.js
+++ b/src/components/Card/components/ShareIconButton/ShareIconButton.js
@@ -5,12 +5,7 @@ import TooltipIconButton from "components/TooltipIconButton/TooltipIconButton";
 import ShareIcon from "@mui/icons-material/Share";
 
 const ShareIconButton = () => {
-  return (
-    <TooltipIconButton 
-      icon={<ShareIcon />}
-      title={"Share"}
-    />
-  );
-}
+  return <TooltipIconButton icon={<ShareIcon />} title={"Share"} />;
+};
 
 export default ShareIconButton;

--- a/src/components/Card/components/ShareIconButton/ShareIconButton.test.js
+++ b/src/components/Card/components/ShareIconButton/ShareIconButton.test.js
@@ -1,1 +1,1 @@
-test.todo('write tests')
+test.todo("write tests");

--- a/src/components/CardGrid/CardGrid.js
+++ b/src/components/CardGrid/CardGrid.js
@@ -5,17 +5,13 @@ import ExpandableGridItemCard from "components/ExpandableGridItemCard/Expandable
 import { Grid } from "@mui/material";
 
 const CardGrid = (props) => {
-
   return (
     <Grid container spacing={2}>
       {props.tablature.map((tab, index) => (
-        <ExpandableGridItemCard 
-          tabData={tab}
-          key={index}
-        />
+        <ExpandableGridItemCard tabData={tab} key={index} />
       ))}
     </Grid>
   );
-}
- 
+};
+
 export default CardGrid;

--- a/src/components/CardGrid/CardGrid.test.js
+++ b/src/components/CardGrid/CardGrid.test.js
@@ -1,10 +1,10 @@
-import { screen } from '@testing-library/react'
-import CardGrid from './CardGrid'
-import { renderWithUserContext } from 'utils/TestUtils/TestUtils'
-import { testTab } from 'utils/TestUtils/TestTabObject'
+import { screen } from "@testing-library/react";
+import CardGrid from "./CardGrid";
+import { renderWithUserContext } from "utils/TestUtils/TestUtils";
+import { testTab } from "utils/TestUtils/TestTabObject";
 
-test('renders cards', ()=> {
-  const tablature = [testTab, testTab]
-  renderWithUserContext(<CardGrid tablature={tablature} />)
-  expect(screen.queryAllByText('test tab').length).toBe(2)
-})
+test("renders cards", () => {
+  const tablature = [testTab, testTab];
+  renderWithUserContext(<CardGrid tablature={tablature} />);
+  expect(screen.queryAllByText("test tab").length).toBe(2);
+});

--- a/src/components/ExpandableGridItemCard/ExpandableGridItemCard.js
+++ b/src/components/ExpandableGridItemCard/ExpandableGridItemCard.js
@@ -10,7 +10,7 @@ const ExpandableGridItemCard = (props) => {
   const handleExpand = () => setIsExpanded(!isExpanded);
 
   return (
-    <Grid item lg={isExpanded ? 12 : 6} xs={12} >
+    <Grid item lg={isExpanded ? 12 : 6} xs={12}>
       <Card
         handleExpand={handleExpand}
         tabData={props.tabData}
@@ -18,6 +18,6 @@ const ExpandableGridItemCard = (props) => {
       />
     </Grid>
   );
-}
- 
+};
+
 export default ExpandableGridItemCard;

--- a/src/components/ExpandableGridItemCard/ExpandableGridItemCard.test.js
+++ b/src/components/ExpandableGridItemCard/ExpandableGridItemCard.test.js
@@ -1,15 +1,17 @@
-import { render, screen } from '@testing-library/react'
-import ExpandableGridItemCard from './ExpandableGridItemCard'
-import { testTab } from 'utils/TestUtils/TestTabObject'
-import { BrowserRouter } from 'react-router-dom'
+import { render, screen } from "@testing-library/react";
+import ExpandableGridItemCard from "./ExpandableGridItemCard";
+import { testTab } from "utils/TestUtils/TestTabObject";
+import { BrowserRouter } from "react-router-dom";
 import userEvent from "@testing-library/user-event";
 
-test('grid expands when expand button is clicked', async ()=> {
+test("grid expands when expand button is clicked", async () => {
   const testUser = {
-    username: 'testUser'
-  }
-  const user = userEvent.setup()
-  render(<ExpandableGridItemCard tabData={testTab} user={testUser}/>, {wrapper: BrowserRouter})
-  await user.click(screen.getByLabelText('Expand'))
-  expect(screen.getByText('test bar A')).toBeInTheDocument()
-})
+    username: "testUser",
+  };
+  const user = userEvent.setup();
+  render(<ExpandableGridItemCard tabData={testTab} user={testUser} />, {
+    wrapper: BrowserRouter,
+  });
+  await user.click(screen.getByLabelText("Expand"));
+  expect(screen.getByText("test bar A")).toBeInTheDocument();
+});

--- a/src/components/TablatureBlock/TablatureBlock.js
+++ b/src/components/TablatureBlock/TablatureBlock.js
@@ -1,15 +1,15 @@
 // Components / hooks
 import SimpleBar from "simplebar-react";
-import 'simplebar/dist/simplebar.min.css';
+import "simplebar/dist/simplebar.min.css";
 
-import "./TablatureBlockStyle.css"
+import "./TablatureBlockStyle.css";
 
 // MUI hook that gives components access to theme stored in ThemeProvider
 import { useTheme } from "@mui/material/styles";
 
 const TablatureBlock = (props) => {
   const theme = useTheme(); // theme obtained with invoking this hook
-  
+
   const inputsStyle = {
     background: "transparent",
     margin: 0,
@@ -21,7 +21,7 @@ const TablatureBlock = (props) => {
     border: "none",
     color: theme.palette.primary.main,
   };
-  
+
   const dashesStyle = {
     background: "transparent",
     margin: 0,
@@ -38,7 +38,9 @@ const TablatureBlock = (props) => {
 
   return (
     <SimpleBar>
-      <div style={{ position: "relative", width: "fit-content", margin: "0 auto"}}>
+      <div
+        style={{ position: "relative", width: "fit-content", margin: "0 auto" }}
+      >
         <textarea
           readOnly={true}
           style={inputsStyle}
@@ -46,7 +48,7 @@ const TablatureBlock = (props) => {
           cols={props.blockData.cols}
           rows={props.numberOfStrings}
           maxLength={props.blockData.maxLength}
-          />
+        />
         <textarea
           readOnly={true}
           style={dashesStyle}

--- a/src/components/TablatureBlock/TablatureBlock.test.js
+++ b/src/components/TablatureBlock/TablatureBlock.test.js
@@ -1,9 +1,9 @@
-import { render, screen } from "@testing-library/react"
-import TablatureBlock from './TablatureBlock'
-import { sampleTablatureBlock } from "utils/TestUtils/TestUtils" 
+import { render, screen } from "@testing-library/react";
+import TablatureBlock from "./TablatureBlock";
+import { sampleTablatureBlock } from "utils/TestUtils/TestUtils";
 
 test('renders both "inputs" and "dashes" text areas', () => {
-  render(<TablatureBlock blockData={sampleTablatureBlock} />)
-  expect(screen.getByText(sampleTablatureBlock.inputs)).toBeInTheDocument()
-  expect(screen.getByText(sampleTablatureBlock.dashes)).toBeInTheDocument()
-})
+  render(<TablatureBlock blockData={sampleTablatureBlock} />);
+  expect(screen.getByText(sampleTablatureBlock.inputs)).toBeInTheDocument();
+  expect(screen.getByText(sampleTablatureBlock.dashes)).toBeInTheDocument();
+});

--- a/src/components/TablatureBlock/TablatureBlockStyle.css
+++ b/src/components/TablatureBlock/TablatureBlockStyle.css
@@ -1,3 +1,3 @@
 .simplebar-scrollbar::before {
-  background-color: #4C566A;
+  background-color: #4c566a;
 }

--- a/src/components/ToggledIconButton/ToggledIconButton.js
+++ b/src/components/ToggledIconButton/ToggledIconButton.js
@@ -4,50 +4,46 @@ import TooltipIconButton from "components/TooltipIconButton/TooltipIconButton";
 
 const ToggledIconButton = (props) => {
   const [showIconA, setShowIconA] = useState(
-    props.startOnA === undefined || props.startOnA === true
-    ? true
-    : false
-  )
+    props.startOnA === undefined || props.startOnA === true ? true : false
+  );
 
-  const titleA = props.titleA === undefined ? "" : props.titleA
-  const titleB = props.titleB === undefined ? "" : props.titleB
+  const titleA = props.titleA === undefined ? "" : props.titleA;
+  const titleB = props.titleB === undefined ? "" : props.titleB;
 
   const handleClick = () => {
-    if(showIconA) {
-      props.handleClickA()
+    if (showIconA) {
+      props.handleClickA();
     } else {
-      props.handleClickB()
+      props.handleClickB();
     }
-    setShowIconA(!showIconA)
-  }
+    setShowIconA(!showIconA);
+  };
 
   useEffect(() => {
-    setShowIconA(props.startOnA === undefined || props.startOnA === true
-      ? true
-      : false
-    )
-  }, [props.startOnA])
+    setShowIconA(
+      props.startOnA === undefined || props.startOnA === true ? true : false
+    );
+  }, [props.startOnA]);
 
   return (
     <>
-      {showIconA
-        ?
-          <TooltipIconButton
-            isDisabled={props.isDisabled}
-            title={titleA}
-            icon={props.iconA}
-            onClick={handleClick}
-          />
-        :
-          <TooltipIconButton
-            isDisabled={props.isDisabled}
-            title={titleB}
-            icon={props.iconB}
-            onClick={handleClick}
-          />
-      }
+      {showIconA ? (
+        <TooltipIconButton
+          isDisabled={props.isDisabled}
+          title={titleA}
+          icon={props.iconA}
+          onClick={handleClick}
+        />
+      ) : (
+        <TooltipIconButton
+          isDisabled={props.isDisabled}
+          title={titleB}
+          icon={props.iconB}
+          onClick={handleClick}
+        />
+      )}
     </>
   );
-}
- 
+};
+
 export default ToggledIconButton;

--- a/src/components/ToggledIconButton/ToggledIconButton.test.js
+++ b/src/components/ToggledIconButton/ToggledIconButton.test.js
@@ -1,43 +1,51 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import ToggledIconButton from './ToggledIconButton'
+import ToggledIconButton from "./ToggledIconButton";
 import OpenInFullIcon from "@mui/icons-material/OpenInFull";
 import CloseFullscreenRoundedIcon from "@mui/icons-material/CloseFullscreenRounded";
 
-test('Renders with iconA when startOnA is true', ()=> {
-  render(<ToggledIconButton 
-    iconA={<CloseFullscreenRoundedIcon />}
-    iconB={<OpenInFullIcon />}
-    startOnA={true}
-  />)
-  expect(screen.getByTestId('CloseFullscreenRoundedIcon')).toBeInTheDocument()
-})
+test("Renders with iconA when startOnA is true", () => {
+  render(
+    <ToggledIconButton
+      iconA={<CloseFullscreenRoundedIcon />}
+      iconB={<OpenInFullIcon />}
+      startOnA={true}
+    />
+  );
+  expect(screen.getByTestId("CloseFullscreenRoundedIcon")).toBeInTheDocument();
+});
 
-test('Renders with iconA when startOnA is undefined', ()=> {
-  render(<ToggledIconButton 
-    iconA={<CloseFullscreenRoundedIcon />}
-    iconB={<OpenInFullIcon />}
-  />)
-  expect(screen.getByTestId('CloseFullscreenRoundedIcon')).toBeInTheDocument()
-})
+test("Renders with iconA when startOnA is undefined", () => {
+  render(
+    <ToggledIconButton
+      iconA={<CloseFullscreenRoundedIcon />}
+      iconB={<OpenInFullIcon />}
+    />
+  );
+  expect(screen.getByTestId("CloseFullscreenRoundedIcon")).toBeInTheDocument();
+});
 
-test('Renders with iconB when startOnA is false', ()=> {
-  render(<ToggledIconButton 
-    iconA={<CloseFullscreenRoundedIcon />}
-    iconB={<OpenInFullIcon />}
-    startOnA={false}
-  />)
-  expect(screen.getByTestId('OpenInFullIcon')).toBeInTheDocument()
-})
+test("Renders with iconB when startOnA is false", () => {
+  render(
+    <ToggledIconButton
+      iconA={<CloseFullscreenRoundedIcon />}
+      iconB={<OpenInFullIcon />}
+      startOnA={false}
+    />
+  );
+  expect(screen.getByTestId("OpenInFullIcon")).toBeInTheDocument();
+});
 
-test('switches from iconA to iconB when icon button is clicked', async ()=> {
-  render(<ToggledIconButton 
-    iconA={<CloseFullscreenRoundedIcon />}
-    iconB={<OpenInFullIcon />}
-    handleClickA={()=> null}
-    handleClickB={()=> null}
-  />)
-  const user = userEvent.setup()
-  await user.click(screen.getByTestId('CloseFullscreenRoundedIcon'))
-  expect(screen.getByTestId('OpenInFullIcon')).toBeInTheDocument()
-})
+test("switches from iconA to iconB when icon button is clicked", async () => {
+  render(
+    <ToggledIconButton
+      iconA={<CloseFullscreenRoundedIcon />}
+      iconB={<OpenInFullIcon />}
+      handleClickA={() => null}
+      handleClickB={() => null}
+    />
+  );
+  const user = userEvent.setup();
+  await user.click(screen.getByTestId("CloseFullscreenRoundedIcon"));
+  expect(screen.getByTestId("OpenInFullIcon")).toBeInTheDocument();
+});

--- a/src/components/TooltipIconButton/TooltipIconButton.js
+++ b/src/components/TooltipIconButton/TooltipIconButton.js
@@ -4,14 +4,11 @@ import { IconButton, Tooltip } from "@mui/material";
 const TooltipIconButton = (props) => {
   return (
     <Tooltip title={props.title}>
-      <IconButton 
-        onClick={props.onClick}
-        disabled={props.isDisabled} 
-      >
+      <IconButton onClick={props.onClick} disabled={props.isDisabled}>
         {props.icon}
       </IconButton>
     </Tooltip>
   );
-}
- 
+};
+
 export default TooltipIconButton;

--- a/src/components/TooltipIconButton/TooltipIconButton.test.js
+++ b/src/components/TooltipIconButton/TooltipIconButton.test.js
@@ -1,13 +1,15 @@
-import { render, screen } from '@testing-library/react'
-import TooltipIconButton from './TooltipIconButton'
+import { render, screen } from "@testing-library/react";
+import TooltipIconButton from "./TooltipIconButton";
 import OpenInFullIcon from "@mui/icons-material/OpenInFull";
 
-test('Renders tooltipIconButton', async ()=> {
-  render(<TooltipIconButton 
-    title="test"
-    icon={<OpenInFullIcon />}
-    onClick={()=> null}
-  />)
-  expect(screen.getByTestId('OpenInFullIcon')).toBeInTheDocument()
-  expect(screen.getByLabelText('test')).toBeInTheDocument()
-})
+test("Renders tooltipIconButton", async () => {
+  render(
+    <TooltipIconButton
+      title="test"
+      icon={<OpenInFullIcon />}
+      onClick={() => null}
+    />
+  );
+  expect(screen.getByTestId("OpenInFullIcon")).toBeInTheDocument();
+  expect(screen.getByLabelText("test")).toBeInTheDocument();
+});

--- a/src/containers/CognitoUserProvider/CognitoUserProvider.js
+++ b/src/containers/CognitoUserProvider/CognitoUserProvider.js
@@ -11,7 +11,7 @@ import UserPool from "utils/UserPool";
 const UserContext = createContext({});
 
 const CognitoUserProvider = (props) => {
-  const [user, setUser] = useState(null)
+  const [user, setUser] = useState(null);
   const [userIsLoading, setUserIsLoading] = useState(true);
 
   let navigate = useNavigate();
@@ -98,12 +98,12 @@ const CognitoUserProvider = (props) => {
     // If user is not set, check if there is user data in session storage. This allows users to return to the app without having to log back in each time.
     if (!user) {
       const userFromPool = UserPool.getCurrentUser();
-      setUserIsLoading(true)
-      setUserIsLoading(false)
+      setUserIsLoading(true);
+      setUserIsLoading(false);
       setUser(userFromPool);
     }
     if (user && user.profile) {
-      setUserIsLoading(false)
+      setUserIsLoading(false);
     }
 
     // Fetch Profile from the backend if it doesn't exist in user state. Profile is the MongoDB Document associated with the user.
@@ -111,36 +111,36 @@ const CognitoUserProvider = (props) => {
       const userFromPool = UserPool.getCurrentUser();
       const idToken = userUtils.getIdTokenFromUser(userFromPool);
       profileServices
-      .getProfileOfLoggedInUser(userFromPool.username, idToken)
-      .then((response) => {
-        const profile = response.profile;
-        userFromPool["profile"] = profile;
-        // TODO Remove tabsWithOwnerInfo -- not needed for non-public build
-        const tabsWithOwnerInfo = profile.tablature.map((tab)=> {
-          const owner = {
-            _id: tab._id,
-            preferredUsername: profile.preferredUsername,
-            user: user.username,
-          }
-          tab.owner = owner
-          return tab
-        })
-        userFromPool.profile.tablature = tabsWithOwnerInfo
+        .getProfileOfLoggedInUser(userFromPool.username, idToken)
+        .then((response) => {
+          const profile = response.profile;
+          userFromPool["profile"] = profile;
+          // TODO Remove tabsWithOwnerInfo -- not needed for non-public build
+          const tabsWithOwnerInfo = profile.tablature.map((tab) => {
+            const owner = {
+              _id: tab._id,
+              preferredUsername: profile.preferredUsername,
+              user: user.username,
+            };
+            tab.owner = owner;
+            return tab;
+          });
+          userFromPool.profile.tablature = tabsWithOwnerInfo;
 
-        // TODO Remove liked tablature stuff
-        // set favorite tablature hash
-        const favoriteTabHash = {}
-        profile.favoriteTablature.forEach((tab) => {
-          favoriteTabHash[tab._id] = true
-        })
-        userFromPool.profile.favoriteTabHash = favoriteTabHash
+          // TODO Remove liked tablature stuff
+          // set favorite tablature hash
+          const favoriteTabHash = {};
+          profile.favoriteTablature.forEach((tab) => {
+            favoriteTabHash[tab._id] = true;
+          });
+          userFromPool.profile.favoriteTabHash = favoriteTabHash;
 
-        setUserIsLoading(false)
-        setUser(userFromPool);
-      });
+          setUserIsLoading(false);
+          setUser(userFromPool);
+        });
     }
   }, [user]);
- 
+
   return (
     <UserContext.Provider
       value={{
@@ -149,12 +149,12 @@ const CognitoUserProvider = (props) => {
         logout,
         user,
         setUser,
-        userIsLoading
+        userIsLoading,
       }}
     >
       {props.children}
     </UserContext.Provider>
   );
-}
- 
-export { CognitoUserProvider, UserContext }
+};
+
+export { CognitoUserProvider, UserContext };

--- a/src/containers/CognitoUserProvider/CognitoUserProvider.test.js
+++ b/src/containers/CognitoUserProvider/CognitoUserProvider.test.js
@@ -1,1 +1,1 @@
-test.todo('write tests')
+test.todo("write tests");

--- a/src/containers/TablatureProvider/TablatureProvider.js
+++ b/src/containers/TablatureProvider/TablatureProvider.js
@@ -9,83 +9,84 @@ import { getIdTokenFromUser } from "utils/userUtils";
 const TablatureContext = createContext({});
 
 const TablatureProvider = (props) => {
-  const [usersTablature, setUsersTablature] = useState([])
+  const [usersTablature, setUsersTablature] = useState([]);
   // TODO Remove liked tablature stuff
-  const [usersLikedTablature, setUsersLikedTablature] = useState({})
-  const { user } = useContext(UserContext)
+  const [usersLikedTablature, setUsersLikedTablature] = useState({});
+  const { user } = useContext(UserContext);
 
   const addToUsersTablature = (tab) => {
     setUsersTablature((prev) => {
-      return [tab, ...prev]
-    })
-  }
+      return [tab, ...prev];
+    });
+  };
 
   const deleteFromUsersTablature = (tab_id) => {
     setUsersTablature((prev) => {
-      return prev.filter((tab) => tab._id !== tab_id)
-    })
-  }
+      return prev.filter((tab) => tab._id !== tab_id);
+    });
+  };
 
   const updateUserTablature = (updatedTab) => {
     setUsersTablature((prev) => {
       return prev.map((tab) => {
-        let tabObject = {}
-        if(tab._id === updatedTab._id) {
-          tabObject = { ...updatedTab }
+        let tabObject = {};
+        if (tab._id === updatedTab._id) {
+          tabObject = { ...updatedTab };
         } else {
-          tabObject = { ...tab }
+          tabObject = { ...tab };
         }
-        return tabObject
-      })
-    })
-  }
+        return tabObject;
+      });
+    });
+  };
 
   // TODO Remove liked tablature stuff
   const addToUsersLikedTablature = (tab_id) => {
     setUsersLikedTablature((prev) => {
-      prev[tab_id] = true
-      return { ...prev }
-    })
-  }
+      prev[tab_id] = true;
+      return { ...prev };
+    });
+  };
   // TODO Remove liked tablature stuff
   const removeFromUsersLikedTablature = (tab_id) => {
     setUsersLikedTablature((prev) => {
-      delete prev[tab_id]
-      return({...prev})
-    })
-  }
+      delete prev[tab_id];
+      return { ...prev };
+    });
+  };
 
-  const getTabFromUser =(tab_id) => usersTablature.find((tab) => tab._id === tab_id)
+  const getTabFromUser = (tab_id) =>
+    usersTablature.find((tab) => tab._id === tab_id);
 
   useEffect(() => {
-    if(user) {
-      const idToken = getIdTokenFromUser(user)
+    if (user) {
+      const idToken = getIdTokenFromUser(user);
 
       // Get users tablature
       profileServices
-      .getProfileOfLoggedInUser(user.username, idToken)
-      .then((response) => {
-        const profile = response.profile;
-        const tabsWithOwnerInfo = profile.tablature.map((tab)=> {
-          const owner = {
-            _id: tab._id,
-            preferredUsername: profile.preferredUsername,
-            user: user.username,
-          }
-          tab.owner = owner
-          return tab
-        })
-        setUsersTablature(tabsWithOwnerInfo)
-        // TODO Remove liked tablature stuff
-        // get users liked tablature
-        const favoriteTabHash = {}
-        profile.favoriteTablature.forEach((tab) => {
-          favoriteTabHash[tab._id] = true
-        })
-        setUsersLikedTablature(favoriteTabHash)
-      })
+        .getProfileOfLoggedInUser(user.username, idToken)
+        .then((response) => {
+          const profile = response.profile;
+          const tabsWithOwnerInfo = profile.tablature.map((tab) => {
+            const owner = {
+              _id: tab._id,
+              preferredUsername: profile.preferredUsername,
+              user: user.username,
+            };
+            tab.owner = owner;
+            return tab;
+          });
+          setUsersTablature(tabsWithOwnerInfo);
+          // TODO Remove liked tablature stuff
+          // get users liked tablature
+          const favoriteTabHash = {};
+          profile.favoriteTablature.forEach((tab) => {
+            favoriteTabHash[tab._id] = true;
+          });
+          setUsersLikedTablature(favoriteTabHash);
+        });
     }
-  }, [user])
+  }, [user]);
 
   // TODO Remove liked tablature stuff
   return (
@@ -104,6 +105,6 @@ const TablatureProvider = (props) => {
       {props.children}
     </TablatureContext.Provider>
   );
-}
- 
-export { TablatureProvider, TablatureContext }
+};
+
+export { TablatureProvider, TablatureContext };

--- a/src/pages/Home/Home.js
+++ b/src/pages/Home/Home.js
@@ -1,41 +1,40 @@
-// Components
-import Sidebar from './components/Sidebar/Sidebar';
+// Components / Hooks
+import Sidebar from "./components/Sidebar/Sidebar";
 import ContentRoutes from "./components/ContentRoutes/ContentRoutes";
-import HeaderLinks from './components/HeaderLinks/HeaderLinks';
-import HeaderLogo from './components/HeaderLogo/HeaderLogo';
-import TagBar from './components/TagBar/TagBar';
-import { useState } from 'react';
+import HeaderLinks from "./components/HeaderLinks/HeaderLinks";
+import HeaderLogo from "./components/HeaderLogo/HeaderLogo";
+import TagBar from "./components/TagBar/TagBar";
+import { useState } from "react";
 
 // MUI
 import { Divider, Grid } from "@mui/material";
 
 const Home = () => {
-  const [tags, setTags] = useState([])
+  const [tags, setTags] = useState([]);
 
   const addTag = (tag) => {
-    if(tags.includes(tag) || tag === '' || tag === ' ') {
-      return
+    if (tags.includes(tag) || tag === "" || tag === " ") {
+      return;
     }
-    setTags((prev)=> [...prev, tag])
-  }
+    setTags((prev) => [...prev, tag]);
+  };
 
-  const deleteTag = (tagToDelete) => setTags(tags.filter((tag) => tag !== tagToDelete))
+  const deleteTag = (tagToDelete) =>
+    setTags(tags.filter((tag) => tag !== tagToDelete));
 
-  const clearTags = () => setTags([])
+  const clearTags = () => setTags([]);
 
   return (
     <div data-testid="Home">
       <Grid container>
-
         <Grid item xs={12}>
           <Grid container>
-
-            <Grid item xs={2}>
+            <Grid item xs={2} sx={{ minWidth: "220px" }}>
               <HeaderLogo />
             </Grid>
 
-            <Grid item xs={8}>        
-              <TagBar 
+            <Grid item xs={8}>
+              <TagBar
                 addTag={addTag}
                 deleteTag={deleteTag}
                 clearTags={clearTags}
@@ -43,36 +42,30 @@ const Home = () => {
               />
             </Grid>
 
-            <Grid item xs={2}>        
-              <HeaderLinks />      
+            <Grid item xs={2} sx={{ minWidth: "220px" }}>
+              <HeaderLinks />
             </Grid>
-            
-          </Grid> 
+          </Grid>
         </Grid>
 
         <Grid item xs={12}>
           <Divider variant="middle" />
         </Grid>
 
-        <Grid item xs={2}>                
-          <Sidebar 
-            addTag={addTag}
-          />
+        <Grid item xs={2} sx={{ minWidth: "220px" }}>
+          <Sidebar addTag={addTag} />
         </Grid>
 
         <Grid item xs={8}>
-          <ContentRoutes 
-            tags={tags}
-          />
+          <ContentRoutes tags={tags} />
         </Grid>
 
-        <Grid item xs={2}>
+        <Grid item xs={2} sx={{ minWidth: "100px", padding: "10px" }}>
           Ad
         </Grid>
-
       </Grid>
     </div>
   );
-}
- 
+};
+
 export default Home;

--- a/src/pages/Home/Home.test.js
+++ b/src/pages/Home/Home.test.js
@@ -5,9 +5,9 @@
 // import React from 'react'
 // import Home from "./Home";
 
-test.todo('fix broken tests')
+test.todo("fix broken tests");
 
-// Helper functions ---- 
+// Helper functions ----
 
 // const testIfTrendingContentIsInTheDocument = () => {
 //   expect(screen.getByTestId('TrendingContent')).toBeInTheDocument()
@@ -38,7 +38,6 @@ test.todo('fix broken tests')
 
 // test.todo('Home rendes Header on initial load')
 // test.todo('Home renders ad space on initial load')
-
 
 // // Unit tests ----
 
@@ -183,14 +182,14 @@ test.todo('fix broken tests')
 //   // Test trending link
 //   await user.click(screen.getByText(/latest/i))
 //   testIfTrendingContentIsInTheDocument()
-  
+
 // })
 
 // test('Content area properly swaps between ProfileContent, TrendingContent, and LoginForm for users who are not logged in', async ()=> {
 
 //   render(<Home />, {wrapper: BrowserRouter})
 //   const user = userEvent.setup()
-  
+
 //   // Initial load
 //   expect(screen.getByTestId('OfficialNavPlus')).toBeInTheDocument()
 //   testIfTrendingContentIsInTheDocument()
@@ -210,5 +209,5 @@ test.todo('fix broken tests')
 //   // Test trending link
 //   await user.click(screen.getByText(/latest/i))
 //   testIfTrendingContentIsInTheDocument()
-  
+
 // })

--- a/src/pages/Home/components/ContentRoutes/ContentRoutes.js
+++ b/src/pages/Home/components/ContentRoutes/ContentRoutes.js
@@ -8,22 +8,21 @@ const ContentRoutes = (props) => {
   return (
     <Routes>
       <Route path="/login" element={<LoginSignupForm />} />
+      <Route path="/profile/:cognitoUsername" element={<ProfileContent />} />
       <Route
-        path="/profile/:cognitoUsername"
-        element={<ProfileContent />}
+        path="/new/guitar"
+        element={
+          <Editor key={"guitar"} numberOfStrings={6} tags={props.tags} />
+        }
       />
-      <Route path="/new/guitar" element={
-        <Editor key={"guitar"} numberOfStrings={6} tags={props.tags} />
-      }/>
-      <Route path="/new/bass" element={
-        <Editor key={"bass"} numberOfStrings={4} tags={props.tags} />
-      }/>
-      <Route path="/edit/:tabId" element={
-        <Editor tags={props.tags} />} 
+      <Route
+        path="/new/bass"
+        element={<Editor key={"bass"} numberOfStrings={4} tags={props.tags} />}
       />
+      <Route path="/edit/:tabId" element={<Editor tags={props.tags} />} />
       <Route path="*" element={<Navigate to="/login" replace />} />
     </Routes>
   );
-}
- 
+};
+
 export default ContentRoutes;

--- a/src/pages/Home/components/ContentRoutes/ContentRoutes.test.js
+++ b/src/pages/Home/components/ContentRoutes/ContentRoutes.test.js
@@ -1,41 +1,42 @@
 import { render, screen } from "@testing-library/react";
-import {MemoryRouter} from 'react-router-dom'
-import ContentRoutes from './ContentRoutes'
+import { MemoryRouter } from "react-router-dom";
+import ContentRoutes from "./ContentRoutes";
 import { UserContext } from "containers/CognitoUserProvider/CognitoUserProvider";
-const setTagBarTitle = () => null
-const tags = []
+const setTagBarTitle = () => null;
+const tags = [];
 
-const renderContentRoutesWithMemoryWrapper = (entries) => render(
-  <MemoryRouter initialEntries={entries}>
-    <ContentRoutes tags={tags} />
-  </MemoryRouter>
-)
+const renderContentRoutesWithMemoryWrapper = (entries) =>
+  render(
+    <MemoryRouter initialEntries={entries}>
+      <ContentRoutes tags={tags} />
+    </MemoryRouter>
+  );
 
-test('/login renders LoginSignupForm component', ()=> {
-  renderContentRoutesWithMemoryWrapper(['/login'])
-  expect(screen.getByText('Login')).toBeInTheDocument()
-})
+test("/login renders LoginSignupForm component", () => {
+  renderContentRoutesWithMemoryWrapper(["/login"]);
+  expect(screen.getByText("Login")).toBeInTheDocument();
+});
 
-test('/profile/:cognitoUsername renders ProfileContent component', ()=> {
+test("/profile/:cognitoUsername renders ProfileContent component", () => {
   const mockUser = {
     value: {
       user: {
-        username: 'JarJar_Binks',
+        username: "JarJar_Binks",
         userDataKey: "pizza",
         profile: {},
-        storage: {}
-      }
-    }
-  }
+        storage: {},
+      },
+    },
+  };
   const component = (
     <UserContext.Provider {...mockUser}>
-      <MemoryRouter initialEntries={['/profile/1']}>
+      <MemoryRouter initialEntries={["/profile/1"]}>
         <ContentRoutes tags={tags} setTagBarTitle={setTagBarTitle} />
       </MemoryRouter>
     </UserContext.Provider>
-  )
-  render(component)
-  expect(screen.getByTestId('ProfileContent')).toBeInTheDocument()
-})
+  );
+  render(component);
+  expect(screen.getByTestId("ProfileContent")).toBeInTheDocument();
+});
 
-test.todo('Renders 404 on bad route')
+test.todo("Renders 404 on bad route");

--- a/src/pages/Home/components/Editor/Editor.js
+++ b/src/pages/Home/components/Editor/Editor.js
@@ -1,41 +1,41 @@
 // Components / hooks
-import { useState, useContext, useEffect } from 'react';
+import { useState, useContext, useEffect } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { UserContext } from "containers/CognitoUserProvider/CognitoUserProvider";
 import { TablatureContext } from "containers/TablatureProvider/TablatureProvider";
-import ExpandableTablatureBlock from './components/ExpandableTablatureBlock/ExpandableTablatureBlock';
-import AddNoteBlockButton from './components/AddNoteBlockButton/AddNoteBlockButton';
-import DeleteTabButton from './components/DeleteTabButton/DeleteTabButton';
-import SaveTabButton from './components/SaveTabButton/SaveTabButton';
-import NoteBlock from './components/NoteBlock/NoteBlock';
-import AddTablatureBlockButton from './components/AddTablatureBlockButton/AddTablatureBlockButton';
+import ExpandableTablatureBlock from "./components/ExpandableTablatureBlock/ExpandableTablatureBlock";
+import AddNoteBlockButton from "./components/AddNoteBlockButton/AddNoteBlockButton";
+import DeleteTabButton from "./components/DeleteTabButton/DeleteTabButton";
+import SaveTabButton from "./components/SaveTabButton/SaveTabButton";
+import NoteBlock from "./components/NoteBlock/NoteBlock";
+import AddTablatureBlockButton from "./components/AddTablatureBlockButton/AddTablatureBlockButton";
 
 // Services / utils
 import { getNewGuitarBlock } from "./utils/EditorUtils";
 
 // MUI
 import { CircularProgress, Paper } from "@mui/material";
-import Box from '@mui/material/Box';
+import Box from "@mui/material/Box";
 
 const Editor = (props) => {
   const [selectedTablatureBlock, setSelectedTablatureBlock] = useState(null);
-  const [cursorPosition, setCursorPosition] = useState({ position: null }); // This can't be a number or it will cause 
+  const [cursorPosition, setCursorPosition] = useState({ position: null }); // This can't be a number or it will cause
   const [showDeleteButton, setShowDeleteButton] = useState(false); // Is the document already in the database?
   const [isLoading, setIsLoading] = useState(false); // is the document currently waiting for a response?
   const [tablature, setTablature] = useState({
     name: "A tasty lick",
     blocks: [],
     tags: [],
-    numberOfStrings: props.numberOfStrings
+    numberOfStrings: props.numberOfStrings,
   });
 
   const { user } = useContext(UserContext);
   const { tabId } = useParams();
-  const { getTabFromUser } = useContext(TablatureContext)
+  const { getTabFromUser } = useContext(TablatureContext);
   let navigate = useNavigate();
 
   const toggleLoading = (value) => setIsLoading(value);
-  
+
   function handleAddCharacter(character, mapOfLastColumnIndexes) {
     if (cursorPosition.position in mapOfLastColumnIndexes) {
       setCursorPosition((prev) => {
@@ -55,7 +55,9 @@ const Editor = (props) => {
         cursorPosition.position
       );
       tablature.blocks[selectedTablatureBlock.index] = newBlock;
-      setTablature((prev) => { return {...prev}})
+      setTablature((prev) => {
+        return { ...prev };
+      });
       setCursorPosition({ position: cursorPosition.position + 1 });
     }
   }
@@ -80,7 +82,9 @@ const Editor = (props) => {
         newCursorPosition
       );
       tablature.blocks[selectedTablatureBlock.index] = newBlock;
-      setTablature((prev) => { return {...prev}})
+      setTablature((prev) => {
+        return { ...prev };
+      });
       setCursorPosition({ position: newCursorPosition });
     }
   }
@@ -89,9 +93,9 @@ const Editor = (props) => {
     "~": handleAddCharacter, // vibrato
     "/": handleAddCharacter, // slide
     "^": handleAddCharacter, // bend
-    "x": handleAddCharacter, // mute
-    "p": handleAddCharacter, // pull off
-    "h": handleAddCharacter, // hammer on
+    x: handleAddCharacter, // mute
+    p: handleAddCharacter, // pull off
+    h: handleAddCharacter, // hammer on
     0: handleAddCharacter,
     1: handleAddCharacter,
     2: handleAddCharacter,
@@ -102,9 +106,9 @@ const Editor = (props) => {
     7: handleAddCharacter,
     8: handleAddCharacter,
     9: handleAddCharacter,
-    "d": handleAddCharacter, // duplicate
-    "Backspace": handleRemoveCharacter,
-  //   insertLineBreak: handlePressingEnter, // Move cursor to the next line (string)
+    d: handleAddCharacter, // duplicate
+    Backspace: handleRemoveCharacter,
+    //   insertLineBreak: handlePressingEnter, // Move cursor to the next line (string)
   };
 
   function getUpdatedTextAreaValues(area, character, insertionIndex) {
@@ -137,11 +141,11 @@ const Editor = (props) => {
   const duplicateBlock = (blockIndex) => {
     const newBlock = {
       tempKey: Date() + Math.random(),
-      ...tablature.blocks[blockIndex]
-    }
-    tablature.blocks.push(newBlock)
-    refreshTablatureObject()
-  }
+      ...tablature.blocks[blockIndex],
+    };
+    tablature.blocks.push(newBlock);
+    refreshTablatureObject();
+  };
 
   const handleNameInput = (event) => {
     const udpatedTablature = {
@@ -164,7 +168,11 @@ const Editor = (props) => {
     }
   };
 
-  const handleBlockChange = (event, mapOfLastColumnIndexes, mapOfFirstColumnIndexes) => {
+  const handleBlockChange = (
+    event,
+    mapOfLastColumnIndexes,
+    mapOfFirstColumnIndexes
+  ) => {
     const key = event.nativeEvent.data;
     console.log(event.nativeEvent.inputType);
     event.preventDefault();
@@ -187,8 +195,10 @@ const Editor = (props) => {
   // Prevent crusor from jumping to end of input.
   useEffect(() => {
     if (selectedTablatureBlock) {
-      selectedTablatureBlock.inputRef.current.selectionStart = cursorPosition.position;
-      selectedTablatureBlock.inputRef.current.selectionEnd = cursorPosition.position;
+      selectedTablatureBlock.inputRef.current.selectionStart =
+        cursorPosition.position;
+      selectedTablatureBlock.inputRef.current.selectionEnd =
+        cursorPosition.position;
       console.log("New cursorPosition: ", cursorPosition.position);
     }
   }, [cursorPosition, selectedTablatureBlock]);
@@ -200,15 +210,15 @@ const Editor = (props) => {
 
   useEffect(() => {
     if (tabId) {
-      const tab = getTabFromUser(tabId)
-      if(tab) {
+      const tab = getTabFromUser(tabId);
+      if (tab) {
         setTablature(getTabFromUser(tabId));
       } else {
-        navigate('/login')
+        navigate("/login");
       }
     }
   }, [tabId, getTabFromUser, navigate]);
-  
+
   useEffect(() => {
     if (user) {
       let username = user.username;
@@ -219,20 +229,22 @@ const Editor = (props) => {
   }, [user]);
 
   useEffect(() => {
-    if(!tabId && tablature.blocks.length === 0) {
-      const newBlock = getNewGuitarBlock(tablature.numberOfStrings)
+    if (!tabId && tablature.blocks.length === 0) {
+      const newBlock = getNewGuitarBlock(tablature.numberOfStrings);
       setTablature((prev) => {
-        prev.blocks = [newBlock]
-        return {...prev}
-      })
+        prev.blocks = [newBlock];
+        return { ...prev };
+      });
     }
-  }, [tabId, tablature.blocks.length, tablature.numberOfStrings])
+  }, [tabId, tablature.blocks.length, tablature.numberOfStrings]);
 
   return (
     <div data-testid="Editor">
-      {isLoading ? ( <CircularProgress /> ) : (
+      {isLoading ? (
+        <CircularProgress />
+      ) : (
         <Paper>
-          <Box sx={{display: 'flex', justifyContent: 'space-between'}}>
+          <Box sx={{ display: "flex", justifyContent: "space-between" }}>
             <input
               type="text"
               name="name"
@@ -240,28 +252,26 @@ const Editor = (props) => {
               onChange={handleNameInput}
               placeholder="A tasty lick"
             />
-            <AddTablatureBlockButton 
+            <AddTablatureBlockButton
               tablature={tablature}
               refreshTablatureObject={refreshTablatureObject}
             />
-            <AddNoteBlockButton 
+            <AddNoteBlockButton
               tablature={tablature}
               refreshTablatureObject={refreshTablatureObject}
             />
-            <SaveTabButton 
+            <SaveTabButton
               tablature={tablature}
               toggleLoading={toggleLoading}
               tags={props.tags}
               refreshTablatureObject={refreshTablatureObject}
             />
-            {showDeleteButton &&
-              <DeleteTabButton 
-                tablature_id={tablature._id}
-              />
-            }
+            {showDeleteButton && (
+              <DeleteTabButton tablature_id={tablature._id} />
+            )}
           </Box>
           {tablature.blocks.map((block, i) => {
-            if(block.blockType === "tablature") {
+            if (block.blockType === "tablature") {
               return (
                 <ExpandableTablatureBlock
                   key={i}
@@ -270,12 +280,12 @@ const Editor = (props) => {
                   duplicateBlock={duplicateBlock}
                   deleteBlock={deleteBlock}
                   handleBlockChange={handleBlockChange}
-                  handleKeyUpInBlock={handleKeyUpInBlock} 
+                  handleKeyUpInBlock={handleKeyUpInBlock}
                   handleClickedBlock={handleClickedBlock}
                   refreshTablatureObject={refreshTablatureObject}
                   numberOfStrings={tablature.numberOfStrings}
                 />
-              )
+              );
             } else {
               return (
                 <NoteBlock
@@ -285,13 +295,13 @@ const Editor = (props) => {
                   deleteBlock={deleteBlock}
                   refreshTablatureObject={refreshTablatureObject}
                 />
-              )
+              );
             }
           })}
         </Paper>
       )}
     </div>
   );
-}
- 
+};
+
 export default Editor;

--- a/src/pages/Home/components/Editor/Editor.test.js
+++ b/src/pages/Home/components/Editor/Editor.test.js
@@ -1,16 +1,14 @@
 import { BrowserRouter } from "react-router-dom";
 import Editor from "./Editor";
-import renderer from 'react-test-renderer';
+import renderer from "react-test-renderer";
 
-test('rendersa new tab correctly', ()=> {
-  const tags = []
+test("rendersa new tab correctly", () => {
+  const tags = [];
   const component = (
     <BrowserRouter>
-      <Editor tags={tags}  />
+      <Editor tags={tags} />
     </BrowserRouter>
-  )
-  const tree = renderer
-    .create(component)
-    .toJSON();
+  );
+  const tree = renderer.create(component).toJSON();
   expect(tree).toMatchSnapshot();
-})
+});

--- a/src/pages/Home/components/Editor/EditorConfig.js
+++ b/src/pages/Home/components/Editor/EditorConfig.js
@@ -1,6 +1,6 @@
-export const STEP_COUNT = 5
-export const BASS_STRING_COUNT = 4
-export const GUITAR_STRING_COUNT = 6
-export const MIN_BLOCK_COLS = 20
-export const DEFAULT_BLOCK_COLS = 40
-export const MAX_BLOCK_COLS = 80
+export const STEP_COUNT = 5;
+export const BASS_STRING_COUNT = 4;
+export const GUITAR_STRING_COUNT = 6;
+export const MIN_BLOCK_COLS = 20;
+export const DEFAULT_BLOCK_COLS = 40;
+export const MAX_BLOCK_COLS = 80;

--- a/src/pages/Home/components/Editor/components/AddNoteBlockButton/AddNoteBlock.test.js
+++ b/src/pages/Home/components/Editor/components/AddNoteBlockButton/AddNoteBlock.test.js
@@ -3,16 +3,18 @@ import { testTab } from "utils/TestUtils/TestUtils";
 import userEvent from "@testing-library/user-event";
 import { render, screen } from "@testing-library/react";
 
-test('adds a note block to the editor', async () => {
-  const tablature = { ...testTab}
-  const refreshTablatureObject = jest.fn()
-  render(<AddNoteBlockButton 
-    tablature={tablature} 
-    refreshTablatureObject={refreshTablatureObject}
-  />)
-  
+test("adds a note block to the editor", async () => {
+  const tablature = { ...testTab };
+  const refreshTablatureObject = jest.fn();
+  render(
+    <AddNoteBlockButton
+      tablature={tablature}
+      refreshTablatureObject={refreshTablatureObject}
+    />
+  );
+
   const user = userEvent.setup();
-  await user.click(screen.getByRole("button"))
+  await user.click(screen.getByRole("button"));
   expect(refreshTablatureObject.mock.calls.length).toBe(1);
-  expect(tablature.blocks.length).toBe(3)
-})
+  expect(tablature.blocks.length).toBe(3);
+});

--- a/src/pages/Home/components/Editor/components/AddNoteBlockButton/AddNoteBlockButton.js
+++ b/src/pages/Home/components/Editor/components/AddNoteBlockButton/AddNoteBlockButton.js
@@ -3,7 +3,7 @@ import TooltipIconButton from "components/TooltipIconButton/TooltipIconButton";
 // utils
 import { getNewNoteBlock } from "../../utils/EditorUtils";
 // MUI
-import TextSnippetIcon from '@mui/icons-material/TextSnippet';
+import TextSnippetIcon from "@mui/icons-material/TextSnippet";
 
 const AddNoteBlockButton = (props) => {
   const handleAddBlock = () => {
@@ -11,19 +11,19 @@ const AddNoteBlockButton = (props) => {
     props.tablature.blocks.forEach((bar) => {
       previousBlocks.push({ ...bar });
     });
-    const newBlock = getNewNoteBlock()
+    const newBlock = getNewNoteBlock();
     props.tablature.blocks = [...previousBlocks, newBlock];
     props.refreshTablatureObject();
-  }
+  };
 
   return (
-    <TooltipIconButton 
+    <TooltipIconButton
       title="Add note block"
       onClick={handleAddBlock}
       isDiabled={false}
       icon={<TextSnippetIcon />}
     />
   );
-}
- 
+};
+
 export default AddNoteBlockButton;

--- a/src/pages/Home/components/Editor/components/AddTablatureBlockButton/AddTablatureBlockButton.js
+++ b/src/pages/Home/components/Editor/components/AddTablatureBlockButton/AddTablatureBlockButton.js
@@ -3,7 +3,7 @@ import TooltipIconButton from "components/TooltipIconButton/TooltipIconButton";
 // utils
 import { getNewGuitarBlock } from "../../utils/EditorUtils";
 // MUI
-import PlaylistAddIcon from '@mui/icons-material/PlaylistAdd';
+import PlaylistAddIcon from "@mui/icons-material/PlaylistAdd";
 
 const AddTablatureBlockButton = (props) => {
   const handleAddBlock = () => {
@@ -11,19 +11,19 @@ const AddTablatureBlockButton = (props) => {
     props.tablature.blocks.forEach((bar) => {
       previousBlocks.push({ ...bar });
     });
-    const newBlock = getNewGuitarBlock(props.tablature.numberOfStrings)
+    const newBlock = getNewGuitarBlock(props.tablature.numberOfStrings);
     props.tablature.blocks = [...previousBlocks, newBlock];
     props.refreshTablatureObject();
-  }
+  };
 
   return (
-    <TooltipIconButton 
+    <TooltipIconButton
       title="Add tablature block"
       onClick={handleAddBlock}
       isDiabled={false}
       icon={<PlaylistAddIcon />}
     />
   );
-}
- 
+};
+
 export default AddTablatureBlockButton;

--- a/src/pages/Home/components/Editor/components/AddTablatureBlockButton/AddTablatureBlockButton.test.js
+++ b/src/pages/Home/components/Editor/components/AddTablatureBlockButton/AddTablatureBlockButton.test.js
@@ -3,16 +3,18 @@ import { testTab } from "utils/TestUtils/TestUtils";
 import userEvent from "@testing-library/user-event";
 import { render, screen } from "@testing-library/react";
 
-test('adds a note block to the editor', async () => {
-  const tablature = { ...testTab}
-  const refreshTablatureObject = jest.fn()
-  render(<AddTablatureBlockButton 
-    tablature={tablature} 
-    refreshTablatureObject={refreshTablatureObject}
-  />)
-  
+test("adds a note block to the editor", async () => {
+  const tablature = { ...testTab };
+  const refreshTablatureObject = jest.fn();
+  render(
+    <AddTablatureBlockButton
+      tablature={tablature}
+      refreshTablatureObject={refreshTablatureObject}
+    />
+  );
+
   const user = userEvent.setup();
-  await user.click(screen.getByRole("button"))
+  await user.click(screen.getByRole("button"));
   expect(refreshTablatureObject.mock.calls.length).toBe(1);
-  expect(tablature.blocks.length).toBe(3)
-})
+  expect(tablature.blocks.length).toBe(3);
+});

--- a/src/pages/Home/components/Editor/components/DeleteTabButton/DeleteTabButton.js
+++ b/src/pages/Home/components/Editor/components/DeleteTabButton/DeleteTabButton.js
@@ -10,7 +10,7 @@ import * as tablatureServices from "services/tablatureServices";
 import { getIdTokenFromUser } from "utils/userUtils";
 
 // MUI
-import DeleteIcon from '@mui/icons-material/Delete';
+import DeleteIcon from "@mui/icons-material/Delete";
 
 const DeleteTabButton = (props) => {
   const { user } = useContext(UserContext);
@@ -18,23 +18,22 @@ const DeleteTabButton = (props) => {
   const navigate = useNavigate();
 
   const handleDelete = () => {
-    deleteFromUsersTablature(props.tablature_id)
+    deleteFromUsersTablature(props.tablature_id);
     const idToken = getIdTokenFromUser(user);
-    tablatureServices.delete(props.tablature_id, idToken)
-    .then((res) => {
+    tablatureServices.delete(props.tablature_id, idToken).then((res) => {
       console.log(res);
     });
-    navigate(`/profile/${user.username}`)
+    navigate(`/profile/${user.username}`);
   };
-  
+
   return (
-    <TooltipIconButton 
+    <TooltipIconButton
       title="Save"
       onClick={handleDelete}
       isDiabled={false}
       icon={<DeleteIcon />}
     />
   );
-}
- 
+};
+
 export default DeleteTabButton;

--- a/src/pages/Home/components/Editor/components/ExpandableTablatureBlock/ExpandableTablatureBlock.js
+++ b/src/pages/Home/components/Editor/components/ExpandableTablatureBlock/ExpandableTablatureBlock.js
@@ -8,41 +8,41 @@ import DashTextarea from "./components/DashTextarea/DashTextarea";
 import { Box } from "@mui/material";
 
 const ExpandableTablatureBlock = (props) => {
-  const deleteBlock = () => props.deleteBlock(props.index)
-  const duplicateBlock = () => props.duplicateBlock(props.index)
+  const deleteBlock = () => props.deleteBlock(props.index);
+  const duplicateBlock = () => props.duplicateBlock(props.index);
   // ! Broken atm
   const handleLabelInput = (event, barIndex) => {
-    event.preventDefault()
+    event.preventDefault();
     const updatedBar = {
       ...props.blocks[barIndex],
       label: event.target.value,
     };
-    props.blocks[barIndex] = updatedBar
+    props.blocks[barIndex] = updatedBar;
     // props.refreshTablatureObject()
-  }
+  };
 
   return (
     <>
-      <Box sx={{display: 'flex', justifyContent: 'space-between'}}>
-        <input 
-          style={{"marginLeft": "10px"}}
+      <Box sx={{ display: "flex", justifyContent: "space-between" }}>
+        <input
+          style={{ marginLeft: "10px" }}
           type="text"
           name="name"
           value={props.block.label}
           onChange={(event) => handleLabelInput(event, props.index)}
           placeholder="label"
         />
-        <BlockOptionsMenu 
-          deleteBlock={deleteBlock} 
+        <BlockOptionsMenu
+          deleteBlock={deleteBlock}
           duplicateBlock={duplicateBlock}
           block={props.block}
           refreshTablatureObject={props.refreshTablatureObject}
         />
       </Box>
-      <Box sx={{display: 'flex'}}>
-        <TablatureGrill numberOfStrings={props.numberOfStrings}/>
-        <div style={{ position: "relative"}}>
-          <InputTextarea 
+      <Box sx={{ display: "flex" }}>
+        <TablatureGrill numberOfStrings={props.numberOfStrings} />
+        <div style={{ position: "relative" }}>
+          <InputTextarea
             handleBlockChange={props.handleBlockChange}
             handleKeyUpInBlock={props.handleKeyUpInBlock}
             handleClickedBlock={props.handleClickedBlock}
@@ -50,7 +50,7 @@ const ExpandableTablatureBlock = (props) => {
             block={props.block}
             numberOfStrings={props.numberOfStrings}
           />
-          <DashTextarea 
+          <DashTextarea
             block={props.block}
             numberOfStrings={props.numberOfStrings}
           />
@@ -58,6 +58,6 @@ const ExpandableTablatureBlock = (props) => {
       </Box>
     </>
   );
-}
- 
+};
+
 export default ExpandableTablatureBlock;

--- a/src/pages/Home/components/Editor/components/ExpandableTablatureBlock/components/BlockOptionsMenu/BlockOptionsMenu.js
+++ b/src/pages/Home/components/Editor/components/ExpandableTablatureBlock/components/BlockOptionsMenu/BlockOptionsMenu.js
@@ -1,88 +1,89 @@
 // Components / hooks
-import { useState } from 'react';
+import { useState } from "react";
 
 // MUI
-import { styled, alpha } from '@mui/material/styles';
-import Button from '@mui/material/Button';
-import Menu from '@mui/material/Menu';
-import MenuItem from '@mui/material/MenuItem';
-import Divider from '@mui/material/Divider';
-import ArchiveIcon from '@mui/icons-material/Archive';
-import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
-import DeleteIcon from '@mui/icons-material/Delete';
-import TablatureSizeSlider from '../TablatureSizeSlider/TablatureSizeSlider';
+import { styled, alpha } from "@mui/material/styles";
+import Button from "@mui/material/Button";
+import Menu from "@mui/material/Menu";
+import MenuItem from "@mui/material/MenuItem";
+import Divider from "@mui/material/Divider";
+import ArchiveIcon from "@mui/icons-material/Archive";
+import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
+import DeleteIcon from "@mui/icons-material/Delete";
+import TablatureSizeSlider from "../TablatureSizeSlider/TablatureSizeSlider";
 
 const StyledMenu = styled((props) => (
   <Menu
     elevation={0}
     anchorOrigin={{
-      vertical: 'bottom',
-      horizontal: 'right',
+      vertical: "bottom",
+      horizontal: "right",
     }}
     transformOrigin={{
-      vertical: 'top',
-      horizontal: 'right',
+      vertical: "top",
+      horizontal: "right",
     }}
     {...props}
   />
 ))(({ theme }) => ({
-  '& .MuiPaper-root': {
+  "& .MuiPaper-root": {
     borderRadius: 6,
     marginTop: theme.spacing(1),
     minWidth: 180,
     color:
-      theme.palette.mode === 'light' ? 'rgb(55, 65, 81)' : theme.palette.grey[300],
+      theme.palette.mode === "light"
+        ? "rgb(55, 65, 81)"
+        : theme.palette.grey[300],
     boxShadow:
-      'rgb(255, 255, 255) 0px 0px 0px 0px, rgba(0, 0, 0, 0.05) 0px 0px 0px 1px, rgba(0, 0, 0, 0.1) 0px 10px 15px -3px, rgba(0, 0, 0, 0.05) 0px 4px 6px -2px',
-    '& .MuiMenu-list': {
-      padding: '4px 0',
+      "rgb(255, 255, 255) 0px 0px 0px 0px, rgba(0, 0, 0, 0.05) 0px 0px 0px 1px, rgba(0, 0, 0, 0.1) 0px 10px 15px -3px, rgba(0, 0, 0, 0.05) 0px 4px 6px -2px",
+    "& .MuiMenu-list": {
+      padding: "4px 0",
     },
-    '& .MuiMenuItem-root': {
-      '& .MuiSvgIcon-root': {
+    "& .MuiMenuItem-root": {
+      "& .MuiSvgIcon-root": {
         fontSize: 18,
         color: theme.palette.text.secondary,
         marginRight: theme.spacing(1.5),
       },
-      '&:active': {
+      "&:active": {
         backgroundColor: alpha(
           theme.palette.primary.main,
-          theme.palette.action.selectedOpacity,
+          theme.palette.action.selectedOpacity
         ),
       },
     },
   },
 }));
 
-
 export default function BlockOptionsMenu(props) {
   const [anchorEl, setAnchorEl] = useState(null);
   const open = Boolean(anchorEl);
-  
+
   const handleClick = (event) => {
     setAnchorEl(event.currentTarget);
   };
-  
+
   const handleClose = () => {
     setAnchorEl(null);
   };
 
   const handleDelete = () => {
-    props.deleteBlock()
-    handleClose()
-  }
+    props.deleteBlock();
+    handleClose();
+  };
 
   const handleDuplicate = () => {
-    props.duplicateBlock()
-    handleClose()
-  }
+    props.duplicateBlock();
+    handleClose();
+  };
 
   return (
     <div>
       <Button
         id="demo-customized-button"
-        aria-controls={open ? 'demo-customized-menu' : undefined}
+        aria-controls={open ? "demo-customized-menu" : undefined}
         aria-haspopup="true"
-        aria-expanded={open ? 'true' : undefined}
+        aria-expanded={open ? "true" : undefined}
         variant="contained"
         disableElevation
         onClick={handleClick}
@@ -93,7 +94,7 @@ export default function BlockOptionsMenu(props) {
       <StyledMenu
         id="demo-customized-menu"
         MenuListProps={{
-          'aria-labelledby': 'demo-customized-button',
+          "aria-labelledby": "demo-customized-button",
         }}
         anchorEl={anchorEl}
         open={open}
@@ -103,7 +104,7 @@ export default function BlockOptionsMenu(props) {
           Size
         </MenuItem>
         <MenuItem disableRipple>
-          <TablatureSizeSlider 
+          <TablatureSizeSlider
             refreshTablatureObject={props.refreshTablatureObject}
             block={props.block}
           />

--- a/src/pages/Home/components/Editor/components/ExpandableTablatureBlock/components/DashTextarea/DashTextarea.js
+++ b/src/pages/Home/components/Editor/components/ExpandableTablatureBlock/components/DashTextarea/DashTextarea.js
@@ -16,7 +16,7 @@ const DashTextarea = (props) => {
     border: "none",
     color: theme.palette.background.default,
     fontSize: "1.2rem",
-    padding: 0
+    padding: 0,
   };
 
   return (
@@ -29,6 +29,6 @@ const DashTextarea = (props) => {
       maxLength={props.block.maxLength}
     />
   );
-}
- 
+};
+
 export default DashTextarea;

--- a/src/pages/Home/components/Editor/components/ExpandableTablatureBlock/components/DashTextarea/DashTextarea.test.js
+++ b/src/pages/Home/components/Editor/components/ExpandableTablatureBlock/components/DashTextarea/DashTextarea.test.js
@@ -1,11 +1,9 @@
 import { getNewGuitarBlock } from "../../../../utils/EditorUtils";
 import DashTextarea from "./DashTextarea";
-import renderer from 'react-test-renderer';
+import renderer from "react-test-renderer";
 
-test('renders correctly using a new tablatureBlock', ()=> {
+test("renders correctly using a new tablatureBlock", () => {
   const block = getNewGuitarBlock();
-  const tree = renderer
-    .create(<DashTextarea block={block}/>)
-    .toJSON();
+  const tree = renderer.create(<DashTextarea block={block} />).toJSON();
   expect(tree).toMatchSnapshot();
 });

--- a/src/pages/Home/components/Editor/components/ExpandableTablatureBlock/components/InputTextarea/InputTextarea.js
+++ b/src/pages/Home/components/Editor/components/ExpandableTablatureBlock/components/InputTextarea/InputTextarea.js
@@ -1,19 +1,26 @@
 // Components / hooks
 import { useRef, useEffect, useState } from "react";
 // Utils / services
-import { getMapOfLastColumnIndexes, getMapOfFirstColumnIndexes } from "../../../../utils/EditorUtils"
+import {
+  getMapOfLastColumnIndexes,
+  getMapOfFirstColumnIndexes,
+} from "../../../../utils/EditorUtils";
 // MUI
 import { useTheme } from "@mui/material/styles";
 
 const InputTextarea = (props) => {
-  const [mapOfLastColumnIndexes, setMapOfLastColumnIndexes] = useState(getMapOfLastColumnIndexes({
-    cols: props.block.cols,
-    stringCount: 6
-  }))
-  const [mapOfFirstColumnIndexes, setMapOfFirstColumnIndexes] = useState(getMapOfFirstColumnIndexes({
-    cols: props.block.cols,
-    stringCount: 6
-  }))
+  const [mapOfLastColumnIndexes, setMapOfLastColumnIndexes] = useState(
+    getMapOfLastColumnIndexes({
+      cols: props.block.cols,
+      stringCount: 6,
+    })
+  );
+  const [mapOfFirstColumnIndexes, setMapOfFirstColumnIndexes] = useState(
+    getMapOfFirstColumnIndexes({
+      cols: props.block.cols,
+      stringCount: 6,
+    })
+  );
 
   const inputRef = useRef();
   const theme = useTheme();
@@ -27,35 +34,47 @@ const InputTextarea = (props) => {
     border: "none",
     color: theme.palette.primary.main,
     fontSize: "1.2rem",
-    padding: 0
+    padding: 0,
   };
 
   useEffect(() => {
-    setMapOfLastColumnIndexes(getMapOfLastColumnIndexes({
-      cols: props.block.cols,
-      stringCount: 6
-    }))
+    setMapOfLastColumnIndexes(
+      getMapOfLastColumnIndexes({
+        cols: props.block.cols,
+        stringCount: 6,
+      })
+    );
 
-    setMapOfFirstColumnIndexes(getMapOfFirstColumnIndexes({
-      cols: props.block.cols,
-      stringCount: 6
-    }))
-  }, [props.block.cols, props.block.maxLength])
-  
+    setMapOfFirstColumnIndexes(
+      getMapOfFirstColumnIndexes({
+        cols: props.block.cols,
+        stringCount: 6,
+      })
+    );
+  }, [props.block.cols, props.block.maxLength]);
+
   return (
     <textarea
       style={inputsStyle}
       value={props.block.inputs}
-      onChange={(event) => props.handleBlockChange(event, mapOfLastColumnIndexes, mapOfFirstColumnIndexes)}
-      onKeyUp={(event) =>  props.handleKeyUpInBlock(event)}
+      onChange={(event) =>
+        props.handleBlockChange(
+          event,
+          mapOfLastColumnIndexes,
+          mapOfFirstColumnIndexes
+        )
+      }
+      onKeyUp={(event) => props.handleKeyUpInBlock(event)}
       onPaste={(event) => event.preventDefault()}
-      onClick={(event) => props.handleClickedBlock(event, props.index, inputRef)}
+      onClick={(event) =>
+        props.handleClickedBlock(event, props.index, inputRef)
+      }
       cols={props.block.cols}
       rows={props.numberOfStrings}
       maxLength={props.block.maxLength}
       ref={inputRef}
     />
   );
-}
- 
+};
+
 export default InputTextarea;

--- a/src/pages/Home/components/Editor/components/ExpandableTablatureBlock/components/InputTextarea/InputTextarea.test.js
+++ b/src/pages/Home/components/Editor/components/ExpandableTablatureBlock/components/InputTextarea/InputTextarea.test.js
@@ -1,21 +1,23 @@
 import { getNewGuitarBlock } from "../../../../utils/EditorUtils";
 import InputTextarea from "./InputTextarea";
-import renderer from 'react-test-renderer';
+import renderer from "react-test-renderer";
 
-test('renders correctly using a new tablatureBlock', ()=> {
+test("renders correctly using a new tablatureBlock", () => {
   const block = getNewGuitarBlock();
-  const handleBlockChange = jest.fn()
-  const handleKeyUpInBlock = jest.fn()
-  const handleClickedBlock = jest.fn()
-  const index = 0
+  const handleBlockChange = jest.fn();
+  const handleKeyUpInBlock = jest.fn();
+  const handleClickedBlock = jest.fn();
+  const index = 0;
   const tree = renderer
-    .create(<InputTextarea 
-      block={block}
-      handleBlockChange={handleBlockChange}
-      handleKeyUpInBlock={handleKeyUpInBlock}
-      handleClickedBlock={handleClickedBlock}
-      index={index}
-    />)
+    .create(
+      <InputTextarea
+        block={block}
+        handleBlockChange={handleBlockChange}
+        handleKeyUpInBlock={handleKeyUpInBlock}
+        handleClickedBlock={handleClickedBlock}
+        index={index}
+      />
+    )
     .toJSON();
   expect(tree).toMatchSnapshot();
 });

--- a/src/pages/Home/components/Editor/components/ExpandableTablatureBlock/components/TablatureSizeSlider/TablatureSizeSlider.js
+++ b/src/pages/Home/components/Editor/components/ExpandableTablatureBlock/components/TablatureSizeSlider/TablatureSizeSlider.js
@@ -1,12 +1,15 @@
 // Components / hooks
 import { useState } from "react";
-import { updateBlockValue, updateTextAreaAttributes } from "../../../../utils/EditorUtils"
+import {
+  updateBlockValue,
+  updateTextAreaAttributes,
+} from "../../../../utils/EditorUtils";
 
 // MUI
-import Slider from '@mui/material/Slider';
+import Slider from "@mui/material/Slider";
 
 const TablatureSizeSlider = (props) => {
-  const [sliderValue, setSliderValue] = useState(props.block.cols)
+  const [sliderValue, setSliderValue] = useState(props.block.cols);
 
   const updateInputAreaSize = (action) => {
     const inputAction = {
@@ -14,10 +17,10 @@ const TablatureSizeSlider = (props) => {
       characterToAdd: " ",
       type: action.type,
       stepCount: action.stepCount,
-      cols: props.block.cols
-    }
-    props.block.inputs = updateBlockValue(inputAction)
-  }
+      cols: props.block.cols,
+    };
+    props.block.inputs = updateBlockValue(inputAction);
+  };
 
   const updateDashAreaSize = (action) => {
     const dashAction = {
@@ -25,10 +28,10 @@ const TablatureSizeSlider = (props) => {
       characterToAdd: "-",
       type: action.type,
       stepCount: action.stepCount,
-      cols: props.block.cols
-    }
-    props.block.dashes = updateBlockValue(dashAction)
-  }
+      cols: props.block.cols,
+    };
+    props.block.dashes = updateBlockValue(dashAction);
+  };
 
   const updateBlockProperties = (action) => {
     // ! Update the string count when bass tabs are implemented
@@ -37,40 +40,40 @@ const TablatureSizeSlider = (props) => {
       maxLength: props.block.maxLength,
       type: action.type,
       stepCount: action.stepCount,
-      stringCount: 6
-    }
-    const { cols, maxLength } = updateTextAreaAttributes(textAreaAction)
-    props.block.cols = cols
-    props.block.maxLength = maxLength
-  }
+      stringCount: 6,
+    };
+    const { cols, maxLength } = updateTextAreaAttributes(textAreaAction);
+    props.block.cols = cols;
+    props.block.maxLength = maxLength;
+  };
 
   const updateBlockSize = (action) => {
-    updateInputAreaSize(action)
-    updateDashAreaSize(action)
-    updateBlockProperties(action)
-    props.refreshTablatureObject()
-  }
+    updateInputAreaSize(action);
+    updateDashAreaSize(action);
+    updateBlockProperties(action);
+    props.refreshTablatureObject();
+  };
 
   const handleSliderChange = (event, value) => {
-    if(value === sliderValue) { 
-      return
+    if (value === sliderValue) {
+      return;
     }
-    
+
     const difference = value - sliderValue;
-    if(difference > 0) {
+    if (difference > 0) {
       updateBlockSize({
         type: "increase",
-        stepCount: difference
-      })
+        stepCount: difference,
+      });
     } else {
       updateBlockSize({
         type: "decrease",
-        stepCount: difference
-      })
+        stepCount: difference,
+      });
     }
 
-    setSliderValue((prev) => prev + difference)
-  }
+    setSliderValue((prev) => prev + difference);
+  };
   return (
     <Slider
       aria-label="Temperature"
@@ -82,6 +85,6 @@ const TablatureSizeSlider = (props) => {
       max={80}
     />
   );
-}
- 
+};
+
 export default TablatureSizeSlider;

--- a/src/pages/Home/components/Editor/components/NoteBlock/NoteBlock.js
+++ b/src/pages/Home/components/Editor/components/NoteBlock/NoteBlock.js
@@ -4,7 +4,7 @@ import TooltipIconButton from "components/TooltipIconButton/TooltipIconButton";
 // MUI
 import { TextareaAutosize } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
-import DeleteIcon from '@mui/icons-material/Delete';
+import DeleteIcon from "@mui/icons-material/Delete";
 
 const NoteBlock = (props) => {
   const theme = useTheme();
@@ -20,11 +20,11 @@ const NoteBlock = (props) => {
     color: theme.palette.primary.main,
     fontSize: "1.2rem",
   };
-  
+
   const handleChange = (event) => {
-    props.block.inputs = event.target.value
+    props.block.inputs = event.target.value;
     props.refreshTablatureObject();
-  }
+  };
 
   return (
     <>
@@ -35,7 +35,7 @@ const NoteBlock = (props) => {
         value={props.block.inputs}
         onChange={handleChange}
       />
-      <TooltipIconButton 
+      <TooltipIconButton
         title={"Delete note"}
         isDiabled={false}
         onClick={() => props.deleteBlock(props.index)}
@@ -43,6 +43,6 @@ const NoteBlock = (props) => {
       />
     </>
   );
-}
- 
+};
+
 export default NoteBlock;

--- a/src/pages/Home/components/Editor/components/NoteBlock/NoteBlock.test.js
+++ b/src/pages/Home/components/Editor/components/NoteBlock/NoteBlock.test.js
@@ -1,27 +1,29 @@
 import NoteBlock from "./NoteBlock";
 import { getNewNoteBlock } from "../../utils/EditorUtils";
-import { render, screen } from '@testing-library/react';
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-test('login form is rendered on load', ()=> {
-  const block = getNewNoteBlock()
-  const deleteBlock = jest.fn()
-  render(<NoteBlock block={block} deleteBlock={deleteBlock}/>)
-  expect(screen.getByLabelText('Delete note')).toBeInTheDocument()
-  expect(screen.getByPlaceholderText('Notes')).toBeInTheDocument()
-})
+test("login form is rendered on load", () => {
+  const block = getNewNoteBlock();
+  const deleteBlock = jest.fn();
+  render(<NoteBlock block={block} deleteBlock={deleteBlock} />);
+  expect(screen.getByLabelText("Delete note")).toBeInTheDocument();
+  expect(screen.getByPlaceholderText("Notes")).toBeInTheDocument();
+});
 
-test.todo('handle input')
+test.todo("handle input");
 
-test('deletes self', async ()=> {
-  const blockA = getNewNoteBlock()
-  const blockB = getNewNoteBlock()
-  let blocks = [blockA, blockB]
-  const deleteBlock = jest.fn((index) => blocks = blocks.filter((b, i) => i !== index))
-  
-  render(<NoteBlock block={blockA} deleteBlock={deleteBlock} index={0}/>)
-  const user = userEvent.setup()
-  await user.click(screen.getByLabelText('Delete note'))
+test("deletes self", async () => {
+  const blockA = getNewNoteBlock();
+  const blockB = getNewNoteBlock();
+  let blocks = [blockA, blockB];
+  const deleteBlock = jest.fn(
+    (index) => (blocks = blocks.filter((b, i) => i !== index))
+  );
+
+  render(<NoteBlock block={blockA} deleteBlock={deleteBlock} index={0} />);
+  const user = userEvent.setup();
+  await user.click(screen.getByLabelText("Delete note"));
   expect(deleteBlock.mock.calls.length).toBe(1);
-  expect(blocks).toEqual([blockB])
-})
+  expect(blocks).toEqual([blockB]);
+});

--- a/src/pages/Home/components/Editor/components/SaveTabButton/SaveTabButton.js
+++ b/src/pages/Home/components/Editor/components/SaveTabButton/SaveTabButton.js
@@ -10,37 +10,37 @@ import * as tablatureServices from "services/tablatureServices";
 import { getIdTokenFromUser } from "utils/userUtils";
 
 // MUI
-import SaveIcon from '@mui/icons-material/Save';
+import SaveIcon from "@mui/icons-material/Save";
 
 const SaveTabButton = (props) => {
   const { user } = useContext(UserContext);
-  const { addToUsersTablature, updateUserTablature } = useContext(TablatureContext);
-  const navigate = useNavigate()
+  const { addToUsersTablature, updateUserTablature } =
+    useContext(TablatureContext);
+  const navigate = useNavigate();
 
   const handleSave = async () => {
     const idToken = getIdTokenFromUser(user);
-    props.tablature.tags = props.tags
+    props.tablature.tags = props.tags;
 
     const updateExistingTablature = () => {
       props.toggleLoading(true);
-      tablatureServices.update(props.tablature, idToken)
-      .then((res) => {
+      tablatureServices.update(props.tablature, idToken).then((res) => {
         console.log(res);
         props.toggleLoading(false);
         props.refreshTablatureObject();
       });
-    }
-  
+    };
+
     const saveNewTablature = () => {
       props.toggleLoading(true);
       return tablatureServices
-      .create(props.tablature, idToken)
-      .then((tablatureFromResponse) => {
-        props.toggleLoading(false);
-        return tablatureFromResponse;
-      });
-    }
-    
+        .create(props.tablature, idToken)
+        .then((tablatureFromResponse) => {
+          props.toggleLoading(false);
+          return tablatureFromResponse;
+        });
+    };
+
     if (props.tablature._id) {
       updateUserTablature(props.tablature);
       updateExistingTablature();
@@ -53,13 +53,13 @@ const SaveTabButton = (props) => {
   };
 
   return (
-    <TooltipIconButton 
+    <TooltipIconButton
       title="Save"
       onClick={handleSave}
       isDiabled={false}
       icon={<SaveIcon />}
     />
   );
-}
- 
+};
+
 export default SaveTabButton;

--- a/src/pages/Home/components/Editor/components/TablatureGrill/TablatureGrill.js
+++ b/src/pages/Home/components/Editor/components/TablatureGrill/TablatureGrill.js
@@ -1,14 +1,14 @@
 // Components / hooks
-import { useState } from 'react';
+import { useState } from "react";
 // MUI
 import { useTheme } from "@mui/material/styles";
 
 const TablatureGrill = (props) => {
-  const guitarGrillValue = `|\n|\n|\n|\n|\n|`
-  const bassGrillValue = `|\n|\n|\n|`
+  const guitarGrillValue = `|\n|\n|\n|\n|\n|`;
+  const bassGrillValue = `|\n|\n|\n|`;
   const [value] = useState(
-    (props.numberOfStrings === 6) ? guitarGrillValue : bassGrillValue
-  )
+    props.numberOfStrings === 6 ? guitarGrillValue : bassGrillValue
+  );
   const theme = useTheme(); // theme obtained with invoking this hook
 
   const breakupStyle = {
@@ -22,18 +22,18 @@ const TablatureGrill = (props) => {
     color: theme.palette.primary.main,
     fontSize: "1.2rem",
     padding: 0,
-    textAlign: "right"
+    textAlign: "right",
   };
 
   return (
     <textarea
-    readOnly={true}
-    style={breakupStyle}
-    value={value}
-    cols={1}
-    rows={props.numberOfStrings}
-  />
+      readOnly={true}
+      style={breakupStyle}
+      value={value}
+      cols={1}
+      rows={props.numberOfStrings}
+    />
   );
-}
- 
+};
+
 export default TablatureGrill;

--- a/src/pages/Home/components/Editor/components/TablatureGrill/TablatureGrill.test.js
+++ b/src/pages/Home/components/Editor/components/TablatureGrill/TablatureGrill.test.js
@@ -1,9 +1,7 @@
 import TablatureGrill from "./TablatureGrill";
-import renderer from 'react-test-renderer';
+import renderer from "react-test-renderer";
 
-test('renders', ()=> {
-  const tree = renderer
-    .create(<TablatureGrill />)
-    .toJSON();
+test("renders", () => {
+  const tree = renderer.create(<TablatureGrill />).toJSON();
   expect(tree).toMatchSnapshot();
 });

--- a/src/pages/Home/components/Editor/utils/EditorUtils.js
+++ b/src/pages/Home/components/Editor/utils/EditorUtils.js
@@ -1,8 +1,15 @@
-import { DEFAULT_BLOCK_COLS, MIN_BLOCK_COLS, MAX_BLOCK_COLS } from '../EditorConfig'
+import {
+  DEFAULT_BLOCK_COLS,
+  MIN_BLOCK_COLS,
+  MAX_BLOCK_COLS,
+} from "../EditorConfig";
 
-const calcNewMaxLength = (numberOfCols, numberOfStrings) => (numberOfCols * numberOfStrings) + (numberOfStrings * 2) - 1
-const calculateNewFirstCol = (numberOfCols, index) => (numberOfCols + 1) * (index)
-const calculateNewLastCol = (numberOfCols, stringNum, index) => (numberOfCols * stringNum) + index
+const calcNewMaxLength = (numberOfCols, numberOfStrings) =>
+  numberOfCols * numberOfStrings + numberOfStrings * 2 - 1;
+const calculateNewFirstCol = (numberOfCols, index) =>
+  (numberOfCols + 1) * index;
+const calculateNewLastCol = (numberOfCols, stringNum, index) =>
+  numberOfCols * stringNum + index;
 
 /* 
   Needs an actions object with the following properties:
@@ -13,29 +20,31 @@ const calculateNewLastCol = (numberOfCols, stringNum, index) => (numberOfCols * 
   stepCount
 */
 export const updateBlockValue = (action) => {
-  if((action.type === "increase" && action.cols === MAX_BLOCK_COLS) ||
-    (action.type === "decrease" && action.cols === MIN_BLOCK_COLS)) {
-    return action.area
+  if (
+    (action.type === "increase" && action.cols === MAX_BLOCK_COLS) ||
+    (action.type === "decrease" && action.cols === MIN_BLOCK_COLS)
+  ) {
+    return action.area;
   }
 
-  const guitarStrings = action.area.split('\n')
-  let newValueString = ""
-  for(let i = 0; i < guitarStrings.length; i++) {
-    const array = [...guitarStrings[i]]
-    for(let j = 0; j < Math.abs(action.stepCount); j++) {
-      if(action.type === "increase") {
-        array.push(action.characterToAdd)
+  const guitarStrings = action.area.split("\n");
+  let newValueString = "";
+  for (let i = 0; i < guitarStrings.length; i++) {
+    const array = [...guitarStrings[i]];
+    for (let j = 0; j < Math.abs(action.stepCount); j++) {
+      if (action.type === "increase") {
+        array.push(action.characterToAdd);
       } else {
-        array.pop()
+        array.pop();
       }
     }
-    if(i !== guitarStrings.length - 1) {
-      array.push("\n")
+    if (i !== guitarStrings.length - 1) {
+      array.push("\n");
     }
-    newValueString += array.join("")
+    newValueString += array.join("");
   }
-  return newValueString
-}
+  return newValueString;
+};
 
 /* 
   action {
@@ -47,48 +56,53 @@ export const updateBlockValue = (action) => {
   }
 */
 export const updateTextAreaAttributes = (action) => {
-  if((action.type === "increase" && action.cols === MAX_BLOCK_COLS) ||
-    (action.type === "decrease" && action.cols === MIN_BLOCK_COLS)) {
+  if (
+    (action.type === "increase" && action.cols === MAX_BLOCK_COLS) ||
+    (action.type === "decrease" && action.cols === MIN_BLOCK_COLS)
+  ) {
     return {
       cols: action.cols,
-      maxLength: action.maxLength
-    }
+      maxLength: action.maxLength,
+    };
   }
 
   return {
     cols: action.cols + action.stepCount,
-    maxLength: calcNewMaxLength(action.cols + action.stepCount, action.stringCount)
-  }
-
-}
+    maxLength: calcNewMaxLength(
+      action.cols + action.stepCount,
+      action.stringCount
+    ),
+  };
+};
 
 export const getMapOfLastColumnIndexes = (action) => {
-  const newLastCols = {}
-  for(let i = 0; i < action.stringCount; i++) {
-    const stringNum = i + 1
-    const newVal = calculateNewLastCol(action.cols, stringNum, i)
-    newLastCols[newVal] = true
+  const newLastCols = {};
+  for (let i = 0; i < action.stringCount; i++) {
+    const stringNum = i + 1;
+    const newVal = calculateNewLastCol(action.cols, stringNum, i);
+    newLastCols[newVal] = true;
   }
-  return newLastCols
-}
+  return newLastCols;
+};
 
 export const getMapOfFirstColumnIndexes = (action) => {
-  const newFirstCols = {}
-  for(let i = 0; i < action.stringCount; i++) {
-    const newVal = calculateNewFirstCol(action.cols, i)
-    newFirstCols[newVal] = true
+  const newFirstCols = {};
+  for (let i = 0; i < action.stringCount; i++) {
+    const newVal = calculateNewFirstCol(action.cols, i);
+    newFirstCols[newVal] = true;
   }
-  return newFirstCols
-}
+  return newFirstCols;
+};
 
 export const getNewGuitarBlock = (stringCount = 6) => {
   const action = {
     stringCount: stringCount,
-    cols: DEFAULT_BLOCK_COLS
-  }
+    cols: DEFAULT_BLOCK_COLS,
+  };
 
-  const mapOfLastColumnIndexes = getMapOfLastColumnIndexes(action)
-  const initLength = (action.stringCount * action.cols) + (action.stringCount - 1)
+  const mapOfLastColumnIndexes = getMapOfLastColumnIndexes(action);
+  const initLength =
+    action.stringCount * action.cols + (action.stringCount - 1);
   const initTextAreaWithValue = (character) => {
     let charactersInString = [];
     for (let i = 0; i < initLength; i++) {
@@ -100,23 +114,23 @@ export const getNewGuitarBlock = (stringCount = 6) => {
     }
     return charactersInString.join("");
   };
-  const inputs = initTextAreaWithValue(" ")
-  const dashes = initTextAreaWithValue("-")
-  const maxLength = calcNewMaxLength(action.cols, action.stringCount)
+  const inputs = initTextAreaWithValue(" ");
+  const dashes = initTextAreaWithValue("-");
+  const maxLength = calcNewMaxLength(action.cols, action.stringCount);
   return {
     tempKey: Date() + Math.random(),
     inputs: inputs,
     dashes: dashes,
     cols: DEFAULT_BLOCK_COLS,
     maxLength: maxLength,
-    blockType: "tablature"
+    blockType: "tablature",
   };
-}
+};
 
 export const getNewNoteBlock = () => {
   return {
     tempKey: Date() + Math.random(),
     blockType: "note",
-    inputs: ""
-  }  
-}
+    inputs: "",
+  };
+};

--- a/src/pages/Home/components/HeaderLinks/AvatarMenu/AvatarMenu.js
+++ b/src/pages/Home/components/HeaderLinks/AvatarMenu/AvatarMenu.js
@@ -1,5 +1,5 @@
 // Services
-import { useState} from "react";
+import { useState } from "react";
 
 // Components
 import Box from "@mui/material/Box";
@@ -11,13 +11,13 @@ import Tooltip from "@mui/material/Tooltip";
 import MenuItem from "@mui/material/MenuItem";
 
 const AvatarMenu = (props) => {
-  // const { logout } = useContext(UserContext);  
+  // const { logout } = useContext(UserContext);
   const [anchorElUser, setAnchorElUser] = useState(null);
-  // const { user } = useContext(UserContext);  
+  // const { user } = useContext(UserContext);
 
   // Handles opening the user avatar menu
   const handleOpenUserMenu = (event) => {
-    console.log(event.currentTarget)
+    console.log(event.currentTarget);
     setAnchorElUser(event.currentTarget);
   };
 
@@ -28,7 +28,7 @@ const AvatarMenu = (props) => {
   const handleMenuItemClick = (onClick) => {
     setAnchorElUser(null);
     onClick();
-  }
+  };
   return (
     <Box sx={{ flexGrow: 0 }}>
       <Tooltip title="Open settings">
@@ -53,13 +53,17 @@ const AvatarMenu = (props) => {
         onClose={handleCloseUserMenu}
       >
         {props.headerLinks?.map((link, i) => {
-          return(
-            <MenuItem onClick={() => handleMenuItemClick(link.onClick)} key={i} disableRipple>
+          return (
+            <MenuItem
+              onClick={() => handleMenuItemClick(link.onClick)}
+              key={i}
+              disableRipple
+            >
               {link.icon}
               {link.name}
             </MenuItem>
-          )
-        })}        
+          );
+        })}
       </Menu>
     </Box>
   );

--- a/src/pages/Home/components/HeaderLinks/CreateMenu/CreateMenu.js
+++ b/src/pages/Home/components/HeaderLinks/CreateMenu/CreateMenu.js
@@ -1,45 +1,47 @@
-import * as React from 'react';
-import { styled, alpha } from '@mui/material/styles';
-import Button from '@mui/material/Button';
-import Menu from '@mui/material/Menu';
-import MenuItem from '@mui/material/MenuItem';
-import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import * as React from "react";
+import { styled, alpha } from "@mui/material/styles";
+import Button from "@mui/material/Button";
+import Menu from "@mui/material/Menu";
+import MenuItem from "@mui/material/MenuItem";
+import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 
 const StyledMenu = styled((props) => (
   <Menu
     elevation={0}
     anchorOrigin={{
-      vertical: 'bottom',
-      horizontal: 'right',
+      vertical: "bottom",
+      horizontal: "right",
     }}
     transformOrigin={{
-      vertical: 'top',
-      horizontal: 'right',
+      vertical: "top",
+      horizontal: "right",
     }}
     {...props}
   />
 ))(({ theme }) => ({
-  '& .MuiPaper-root': {
+  "& .MuiPaper-root": {
     borderRadius: 6,
     marginTop: theme.spacing(1),
     minWidth: 180,
     color:
-      theme.palette.mode === 'light' ? 'rgb(55, 65, 81)' : theme.palette.grey[300],
+      theme.palette.mode === "light"
+        ? "rgb(55, 65, 81)"
+        : theme.palette.grey[300],
     boxShadow:
-      'rgb(255, 255, 255) 0px 0px 0px 0px, rgba(0, 0, 0, 0.05) 0px 0px 0px 1px, rgba(0, 0, 0, 0.1) 0px 10px 15px -3px, rgba(0, 0, 0, 0.05) 0px 4px 6px -2px',
-    '& .MuiMenu-list': {
-      padding: '4px 0',
+      "rgb(255, 255, 255) 0px 0px 0px 0px, rgba(0, 0, 0, 0.05) 0px 0px 0px 1px, rgba(0, 0, 0, 0.1) 0px 10px 15px -3px, rgba(0, 0, 0, 0.05) 0px 4px 6px -2px",
+    "& .MuiMenu-list": {
+      padding: "4px 0",
     },
-    '& .MuiMenuItem-root': {
-      '& .MuiSvgIcon-root': {
+    "& .MuiMenuItem-root": {
+      "& .MuiSvgIcon-root": {
         fontSize: 18,
         color: theme.palette.text.secondary,
         marginRight: theme.spacing(1.5),
       },
-      '&:active': {
+      "&:active": {
         backgroundColor: alpha(
           theme.palette.primary.main,
-          theme.palette.action.selectedOpacity,
+          theme.palette.action.selectedOpacity
         ),
       },
     },
@@ -58,15 +60,15 @@ export default function CustomizedMenus(props) {
   const handleMenuItemClick = (onClick) => {
     setAnchorEl(null);
     onClick();
-  }
+  };
 
   return (
     <div>
       <Button
         id="demo-customized-button"
-        aria-controls={open ? 'demo-customized-menu' : undefined}
+        aria-controls={open ? "demo-customized-menu" : undefined}
         aria-haspopup="true"
-        aria-expanded={open ? 'true' : undefined}
+        aria-expanded={open ? "true" : undefined}
         variant="contained"
         disableElevation
         onClick={handleClick}
@@ -77,20 +79,24 @@ export default function CustomizedMenus(props) {
       <StyledMenu
         id="demo-customized-menu"
         MenuListProps={{
-          'aria-labelledby': 'demo-customized-button',
+          "aria-labelledby": "demo-customized-button",
         }}
         anchorEl={anchorEl}
         open={open}
         onClose={handleClose}
       >
         {props.headerLinks.map((link, i) => {
-          return(
-            <MenuItem onClick={() => handleMenuItemClick(link.onClick)} key={i} disableRipple>
+          return (
+            <MenuItem
+              onClick={() => handleMenuItemClick(link.onClick)}
+              key={i}
+              disableRipple
+            >
               {link.icon}
               {link.name}
             </MenuItem>
-          )
-        })}        
+          );
+        })}
       </StyledMenu>
     </div>
   );

--- a/src/pages/Home/components/HeaderLinks/HeaderLinks.js
+++ b/src/pages/Home/components/HeaderLinks/HeaderLinks.js
@@ -1,72 +1,75 @@
-import { React, useContext } from 'react'
-import { useNavigate } from 'react-router-dom';
-import CustomizedMenus from './CreateMenu/CreateMenu'
-import AddCircleIcon from '@mui/icons-material/AddCircle';
-import AvatarMenu from './AvatarMenu/AvatarMenu';
-import { UserContext } from 'containers/CognitoUserProvider/CognitoUserProvider'
-import LoginButton from './LoginButton/LoginButton'
-import Box from "@mui/material/Box"
+import { React, useContext } from "react";
+import { useNavigate } from "react-router-dom";
+import CustomizedMenus from "./CreateMenu/CreateMenu";
+import AddCircleIcon from "@mui/icons-material/AddCircle";
+import AvatarMenu from "./AvatarMenu/AvatarMenu";
+import { UserContext } from "containers/CognitoUserProvider/CognitoUserProvider";
+import LoginButton from "./LoginButton/LoginButton";
+import Box from "@mui/material/Box";
 
 const HeaderLinks = () => {
-  const navigate = useNavigate()
-  const { user, logout } = useContext(UserContext)
-  
-  const headerLinks = [    
+  const navigate = useNavigate();
+  const { user, logout } = useContext(UserContext);
+
+  const headerLinks = [
     {
-      "name": "New Guitar Tab",
-      "onClick": () => navigate('/new'),
-      "icon": (<AddCircleIcon />),
-      "belongsTo" : "create"
+      name: "New Guitar Tab",
+      onClick: () => navigate("/new"),
+      icon: <AddCircleIcon />,
+      belongsTo: "create",
     },
     {
-      "name": "New Bass Tab",
-      "onClick": () => navigate('/new'),
-      "icon": (<AddCircleIcon />),
-      "belongsTo" : "create"
+      name: "New Bass Tab",
+      onClick: () => navigate("/new"),
+      icon: <AddCircleIcon />,
+      belongsTo: "create",
     },
     {
-      "name": "Login",
-      "onClick": () => navigate('/login'),
-      "icon": (<AddCircleIcon />),      
-      "belongsTo": "avatar",
+      name: "Login",
+      onClick: () => navigate("/login"),
+      icon: <AddCircleIcon />,
+      belongsTo: "avatar",
     },
     {
-      "name": "Logout",
-      "onClick": () => logout(),
-      "icon": (<AddCircleIcon />),
-      "belongsTo": "avatar",
-      "isLoggedInUser": true
-    }
-  ]
+      name: "Logout",
+      onClick: () => logout(),
+      icon: <AddCircleIcon />,
+      belongsTo: "avatar",
+      isLoggedInUser: true,
+    },
+  ];
 
   const buttonStyles = {
-    paddingLeft: '10px',
-    paddingRight: '10px',
-    display: 'inline-block',    
-    justifyContent: 'space-even'
-  }
+    paddingLeft: "10px",
+    paddingRight: "10px",
+    display: "inline-block",
+    justifyContent: "space-even",
+  };
 
   return (
-    <>    
-    <Box style={buttonStyles}>
-      <CustomizedMenus
-      headerLinks={headerLinks.filter((link) => {
-        return link.belongsTo === "create"
-      })} 
-      />
-    </Box>
-    <Box style={buttonStyles}>
-      {user ?
-      <AvatarMenu 
-        headerLinks={headerLinks.filter((link) => {
-          return link.belongsTo === "avatar" && link.isLoggedInUser === true
-        })}
-      />
-      : <LoginButton />
-      }
-    </Box>
+    <>
+      <Box style={buttonStyles}>
+        <CustomizedMenus
+          headerLinks={headerLinks.filter((link) => {
+            return link.belongsTo === "create";
+          })}
+        />
+      </Box>
+      <Box style={buttonStyles}>
+        {user ? (
+          <AvatarMenu
+            headerLinks={headerLinks.filter((link) => {
+              return (
+                link.belongsTo === "avatar" && link.isLoggedInUser === true
+              );
+            })}
+          />
+        ) : (
+          <LoginButton />
+        )}
+      </Box>
     </>
-  )
-}
+  );
+};
 
-export default HeaderLinks
+export default HeaderLinks;

--- a/src/pages/Home/components/LoginSignupForm/LoginSignupForm.test.js
+++ b/src/pages/Home/components/LoginSignupForm/LoginSignupForm.test.js
@@ -1,39 +1,38 @@
-import { render, screen } from '@testing-library/react';
-import LoginSignupForm from './LoginSignupForm';
-import { BrowserRouter } from 'react-router-dom'
+import { render, screen } from "@testing-library/react";
+import LoginSignupForm from "./LoginSignupForm";
+import { BrowserRouter } from "react-router-dom";
 import userEvent from "@testing-library/user-event";
 
-test('login form is rendered on load', ()=> {
-  render(<LoginSignupForm />, {wrapper: BrowserRouter})
-  expect(screen.getByTestId(`LoginForm`)).toBeInTheDocument()
-})
+test("login form is rendered on load", () => {
+  render(<LoginSignupForm />, { wrapper: BrowserRouter });
+  expect(screen.getByTestId(`LoginForm`)).toBeInTheDocument();
+});
 
-test('login form is paired with a "Sign up!" button', ()=> {
-  render(<LoginSignupForm />, {wrapper: BrowserRouter})
-  expect(screen.getByTestId(`LoginForm`)).toBeInTheDocument()
-  expect(screen.getByText('Sign up!')).toBeInTheDocument()
-})
+test('login form is paired with a "Sign up!" button', () => {
+  render(<LoginSignupForm />, { wrapper: BrowserRouter });
+  expect(screen.getByTestId(`LoginForm`)).toBeInTheDocument();
+  expect(screen.getByText("Sign up!")).toBeInTheDocument();
+});
 
-test('clicking the "Sign up!" button shows the signup form with a button to go back to the login form', async ()=> {
-  render(<LoginSignupForm />, {wrapper: BrowserRouter})
-  const user = userEvent.setup()
+test('clicking the "Sign up!" button shows the signup form with a button to go back to the login form', async () => {
+  render(<LoginSignupForm />, { wrapper: BrowserRouter });
+  const user = userEvent.setup();
 
-  await user.click(screen.getByText('Sign up!'))
-  expect(screen.getByText(/signup/i)).toBeInTheDocument()
-  expect(screen.queryByTestId(`LoginForm`)).not.toBeInTheDocument()
-  expect(screen.getByText(/log in!/i)).toBeInTheDocument()
-})
+  await user.click(screen.getByText("Sign up!"));
+  expect(screen.getByText(/signup/i)).toBeInTheDocument();
+  expect(screen.queryByTestId(`LoginForm`)).not.toBeInTheDocument();
+  expect(screen.getByText(/log in!/i)).toBeInTheDocument();
+});
 
-test('clicking the "Log in!" button shows the login form', async ()=> {
-  render(<LoginSignupForm />, {wrapper: BrowserRouter})
-  const user = userEvent.setup()
+test('clicking the "Log in!" button shows the login form', async () => {
+  render(<LoginSignupForm />, { wrapper: BrowserRouter });
+  const user = userEvent.setup();
 
-  await user.click(screen.getByText('Sign up!'))
-  expect(screen.getByText(/signup/i)).toBeInTheDocument()
-  expect(screen.queryByTestId(`LoginForm`)).not.toBeInTheDocument()
-  expect(screen.getByText(/log in!/i)).toBeInTheDocument()
-  await user.click(screen.getByText(/log in!/i))
-  expect(screen.getByTestId(`LoginForm`)).toBeInTheDocument()
-  expect(screen.queryByTestId(/signup/i)).not.toBeInTheDocument()
-
-})
+  await user.click(screen.getByText("Sign up!"));
+  expect(screen.getByText(/signup/i)).toBeInTheDocument();
+  expect(screen.queryByTestId(`LoginForm`)).not.toBeInTheDocument();
+  expect(screen.getByText(/log in!/i)).toBeInTheDocument();
+  await user.click(screen.getByText(/log in!/i));
+  expect(screen.getByTestId(`LoginForm`)).toBeInTheDocument();
+  expect(screen.queryByTestId(/signup/i)).not.toBeInTheDocument();
+});

--- a/src/pages/Home/components/LoginSignupForm/components/LoginForm/LoginForm.js
+++ b/src/pages/Home/components/LoginSignupForm/components/LoginForm/LoginForm.js
@@ -40,11 +40,9 @@ const LoginForm = () => {
           variant="outlined"
           onChange={(event) => setPassword(event.target.value)}
           value={password}
-        />        
+        />
         <Button variant="contained" type="submit">
-          <span data-testid="login-button">
-            Login
-          </span>
+          <span data-testid="login-button">Login</span>
         </Button>
       </Stack>
     </form>

--- a/src/pages/Home/components/LoginSignupForm/components/LoginForm/LoginForm.test.js
+++ b/src/pages/Home/components/LoginSignupForm/components/LoginForm/LoginForm.test.js
@@ -2,13 +2,13 @@ import { render, screen } from "@testing-library/react";
 import { BrowserRouter } from "react-router-dom";
 import LoginForm from "./LoginForm";
 
-test('has email and password fields', () => {
-  render(<LoginForm />, {wrapper: BrowserRouter})
-  expect(screen.getByLabelText('Email')).toBeInTheDocument();
-  expect(screen.getByLabelText('Password')).toBeInTheDocument();
-})
+test("has email and password fields", () => {
+  render(<LoginForm />, { wrapper: BrowserRouter });
+  expect(screen.getByLabelText("Email")).toBeInTheDocument();
+  expect(screen.getByLabelText("Password")).toBeInTheDocument();
+});
 
 test('has "LOGIN" button', () => {
-  render(<LoginForm />, {wrapper: BrowserRouter})
-  expect(screen.getByTestId('login-button')).toBeInTheDocument()
-})
+  render(<LoginForm />, { wrapper: BrowserRouter });
+  expect(screen.getByTestId("login-button")).toBeInTheDocument();
+});

--- a/src/pages/Home/components/LoginSignupForm/components/SignupForm/SignupForm.test.js
+++ b/src/pages/Home/components/LoginSignupForm/components/SignupForm/SignupForm.test.js
@@ -2,12 +2,12 @@ import { render, screen } from "@testing-library/react";
 import { BrowserRouter } from "react-router-dom";
 import SignupForm from "./SignupForm";
 
-test('has email, username, and password fields', () => {
-  render(<SignupForm />, {wrapper: BrowserRouter})
-  expect(screen.getByLabelText('Email')).toBeInTheDocument();
-  expect(screen.getByLabelText('Password')).toBeInTheDocument();
-  expect(screen.getByLabelText('Username')).toBeInTheDocument();
-})
+test("has email, username, and password fields", () => {
+  render(<SignupForm />, { wrapper: BrowserRouter });
+  expect(screen.getByLabelText("Email")).toBeInTheDocument();
+  expect(screen.getByLabelText("Password")).toBeInTheDocument();
+  expect(screen.getByLabelText("Username")).toBeInTheDocument();
+});
 
 // test('has "SIGNUP" button', () => {
 //   render(<SignupForm />, {wrapper: BrowserRouter})

--- a/src/pages/Home/components/ProfileContent/ProfileContent.js
+++ b/src/pages/Home/components/ProfileContent/ProfileContent.js
@@ -5,7 +5,6 @@ import { UserContext } from "containers/CognitoUserProvider/CognitoUserProvider"
 import { TablatureContext } from "containers/TablatureProvider/TablatureProvider";
 import CardGrid from "components/CardGrid/CardGrid";
 
-
 // Services
 import * as profileServices from "services/profileServices";
 
@@ -19,26 +18,27 @@ const ProfileContent = () => {
   const { usersTablature } = useContext(TablatureContext);
 
   useEffect(() => {
-    let subscribed = true
-    if(!userIsLoading && cognitoUsername) {
+    let subscribed = true;
+    if (!userIsLoading && cognitoUsername) {
       if (user.username === cognitoUsername) {
-        setTablature(usersTablature)
+        setTablature(usersTablature);
       } else {
-        profileServices.getUsersPublicInfo(cognitoUsername)
-        .then((res) => {
-          if(subscribed) {
-            setTablature(res.usersTablature.map((tab) => {
-              const owner = {_id: tab._id, ...res.authorInfo}
-              tab.owner = owner
-              return tab
-            }))
+        profileServices.getUsersPublicInfo(cognitoUsername).then((res) => {
+          if (subscribed) {
+            setTablature(
+              res.usersTablature.map((tab) => {
+                const owner = { _id: tab._id, ...res.authorInfo };
+                tab.owner = owner;
+                return tab;
+              })
+            );
           }
-        })
+        });
       }
     }
     return () => {
-      subscribed = false
-    }
+      subscribed = false;
+    };
   }, [cognitoUsername, user, userIsLoading, usersTablature]);
 
   return (
@@ -46,9 +46,7 @@ const ProfileContent = () => {
       {tablature === null ? (
         <CircularProgress />
       ) : (
-        <CardGrid 
-          tablature={tablature}
-        />
+        <CardGrid tablature={tablature} />
       )}
     </div>
   );

--- a/src/pages/Home/components/ProfileContent/ProfileContent.test.js
+++ b/src/pages/Home/components/ProfileContent/ProfileContent.test.js
@@ -1,1 +1,1 @@
-test.todo('write tests')
+test.todo("write tests");

--- a/src/pages/Home/components/Sidebar/Sidebar.js
+++ b/src/pages/Home/components/Sidebar/Sidebar.js
@@ -1,26 +1,24 @@
 // Components / hooks
-import TagSuggestions from './components/TagSuggestions/TagSuggestions'
-import CollectionButton from './components/CollectionButton/CollectionButton';
-import CreateBassTabButton from './components/CreateBassTabButton/CreateBassTabButton';
-import CreateGuitarTabButton from './components/CreateGuitarTabButton/CreateGuitarTabButton';
+import TagSuggestions from "./components/TagSuggestions/TagSuggestions";
+import CollectionButton from "./components/CollectionButton/CollectionButton";
+import CreateBassTabButton from "./components/CreateBassTabButton/CreateBassTabButton";
+import CreateGuitarTabButton from "./components/CreateGuitarTabButton/CreateGuitarTabButton";
 
 // MUI
-import { Container, Divider, Stack } from '@mui/material'
+import { Container, Divider, Stack } from "@mui/material";
 
 function Sidebar(props) {
   return (
     <Container data-testid="Sidebar">
-      <Stack direction="column" sx={{my: 2}}>
+      <Stack direction="column" sx={{ my: 2 }}>
         <CreateBassTabButton />
         <CreateGuitarTabButton />
         <CollectionButton />
       </Stack>
-      <Divider variant="middle" sx={{m: 2}}/>
-      <TagSuggestions 
-        addTag={props.addTag}
-      />
+      <Divider variant="middle" sx={{ m: 2 }} />
+      <TagSuggestions addTag={props.addTag} />
     </Container>
-  )
+  );
 }
 
-export default Sidebar
+export default Sidebar;

--- a/src/pages/Home/components/Sidebar/Sidebar.test.js
+++ b/src/pages/Home/components/Sidebar/Sidebar.test.js
@@ -1,14 +1,12 @@
-import renderer from 'react-test-renderer';
-import Sidebar from './Sidebar'
-import { BrowserRouter } from 'react-router-dom'
-test('renders correctly', ()=> {
+import renderer from "react-test-renderer";
+import Sidebar from "./Sidebar";
+import { BrowserRouter } from "react-router-dom";
+test("renders correctly", () => {
   const component = (
     <BrowserRouter>
       <Sidebar />
     </BrowserRouter>
-  )
-  const tree = renderer
-    .create(component)
-    .toJSON();
+  );
+  const tree = renderer.create(component).toJSON();
   expect(tree).toMatchSnapshot();
-})
+});

--- a/src/pages/Home/components/Sidebar/components/CollectionButton/CollectionButton.js
+++ b/src/pages/Home/components/Sidebar/components/CollectionButton/CollectionButton.js
@@ -4,40 +4,40 @@ import { useEffect, useState, useContext } from "react";
 import { UserContext } from "containers/CognitoUserProvider/CognitoUserProvider";
 
 // MUI
-import Button from '@mui/material/Button';
-import FavoriteIcon from '@mui/icons-material/Favorite';
+import Button from "@mui/material/Button";
+import FavoriteIcon from "@mui/icons-material/Favorite";
 
 const CollectionButton = () => {
-  const [variant, setVariant] = useState("text")
-  const navigate = useNavigate()
-  const location = useLocation()
-  const { user } = useContext(UserContext)
+  const [variant, setVariant] = useState("text");
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { user } = useContext(UserContext);
   const handleClick = () => {
-    user ? navigate(`/profile/${user?.username}`) : navigate('/login')
-  }
+    user ? navigate(`/profile/${user?.username}`) : navigate("/login");
+  };
 
-  useEffect(()=> {
-    const urlData = location.pathname.split('/')
-    const path = urlData[1]
-    const username = urlData[2]
-    if(path === 'profile' && username === user?.username) {
-      setVariant("contained")
+  useEffect(() => {
+    const urlData = location.pathname.split("/");
+    const path = urlData[1];
+    const username = urlData[2];
+    if (path === "profile" && username === user?.username) {
+      setVariant("contained");
     } else {
-      setVariant("text")
+      setVariant("text");
     }
-  }, [location, user])
+  }, [location, user]);
 
-  return (  
-    <Button 
+  return (
+    <Button
       startIcon={<FavoriteIcon />}
       onClick={handleClick}
-      sx={{justifyContent: 'left', pl: '16px', my: 1}}
+      sx={{ justifyContent: "left", pl: "16px", my: 1 }}
       disableElevation
       variant={variant}
     >
       Collection
-    </Button>  
+    </Button>
   );
-}
- 
+};
+
 export default CollectionButton;

--- a/src/pages/Home/components/Sidebar/components/CollectionButton/CollectionButton.test.js
+++ b/src/pages/Home/components/Sidebar/components/CollectionButton/CollectionButton.test.js
@@ -1,15 +1,15 @@
-import renderer from 'react-test-renderer';
+import renderer from "react-test-renderer";
 import { render, screen } from "@testing-library/react";
 import { UserContext } from "containers/CognitoUserProvider/CognitoUserProvider";
-import CollectionButton from './CollectionButton';
-import {BrowserRouter, MemoryRouter} from 'react-router-dom'
+import CollectionButton from "./CollectionButton";
+import { BrowserRouter, MemoryRouter } from "react-router-dom";
 import userEvent from "@testing-library/user-event";
 
 const mockedNavigate = jest.fn();
 
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useNavigate: () => mockedNavigate
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: () => mockedNavigate,
 }));
 
 it('variant is "text" when not at the collections route', () => {
@@ -17,70 +17,66 @@ it('variant is "text" when not at the collections route', () => {
     <MemoryRouter>
       <CollectionButton />
     </MemoryRouter>
-  )
-  const tree = renderer
-    .create(component)
-    .toJSON();
+  );
+  const tree = renderer.create(component).toJSON();
   expect(tree).toMatchSnapshot();
-})
+});
 
-test('variant is "contained" when viewing owned collection', ()=> {
+test('variant is "contained" when viewing owned collection', () => {
   const mockUser = {
     value: {
       user: {
-        username: 'JarJar_Binks',
+        username: "JarJar_Binks",
         userDataKey: "pizza",
-        storage: {}
-      }
-    }
-  }
+        storage: {},
+      },
+    },
+  };
   const component = (
-    <MemoryRouter initialEntries={['/profile/JarJar_Binks']}>
+    <MemoryRouter initialEntries={["/profile/JarJar_Binks"]}>
       <UserContext.Provider {...mockUser}>
         <CollectionButton />
       </UserContext.Provider>
     </MemoryRouter>
-  )
+  );
 
-  const tree = renderer
-  .create(component)
-  .toJSON();
+  const tree = renderer.create(component).toJSON();
   expect(tree).toMatchSnapshot();
-})
+});
 
-test('routes to the current users collection on click', async ()=> {
+test("routes to the current users collection on click", async () => {
   const mockUser = {
     value: {
       user: {
-        username: 'JarJar_Binks',
+        username: "JarJar_Binks",
         userDataKey: "pizza",
-        storage: {}
-      }
-    }
-  }
+        storage: {},
+      },
+    },
+  };
   const component = (
     <BrowserRouter>
       <UserContext.Provider {...mockUser}>
         <CollectionButton />
       </UserContext.Provider>
     </BrowserRouter>
-  )
+  );
 
-  render(component)
-  const user = userEvent.setup()
-  await user.click(screen.getByRole('button'))
-  expect(mockedNavigate).toHaveBeenCalledWith('/profile/JarJar_Binks');
-})
+  render(component);
+  const user = userEvent.setup();
+  await user.click(screen.getByRole("button"));
+  expect(mockedNavigate).toHaveBeenCalledWith("/profile/JarJar_Binks");
+});
 
-test('routes to login on click when there is no user', async ()=> {
+test("routes to login on click when there is no user", async () => {
   const component = (
     <BrowserRouter>
       <CollectionButton />
     </BrowserRouter>
-  )
+  );
 
-  render(component)
-  const user = userEvent.setup()
-  await user.click(screen.getByRole('button'))
-  expect(mockedNavigate).toHaveBeenCalledWith('/login');
-})
+  render(component);
+  const user = userEvent.setup();
+  await user.click(screen.getByRole("button"));
+  expect(mockedNavigate).toHaveBeenCalledWith("/login");
+});

--- a/src/pages/Home/components/Sidebar/components/CreateBassTabButton/CreateBassTabButton.js
+++ b/src/pages/Home/components/Sidebar/components/CreateBassTabButton/CreateBassTabButton.js
@@ -4,41 +4,40 @@ import { useContext, useState, useEffect } from "react";
 import { UserContext } from "containers/CognitoUserProvider/CognitoUserProvider";
 
 // MUI
-import AddCircleIcon from '@mui/icons-material/AddCircle';
-import Button from '@mui/material/Button';
+import AddCircleIcon from "@mui/icons-material/AddCircle";
+import Button from "@mui/material/Button";
 
-const CreateBassTabButton = () => {  
-  const [variant, setVariant] = useState("text")
-  const navigate = useNavigate()
-  const location = useLocation()
-  const { user } = useContext(UserContext)
+const CreateBassTabButton = () => {
+  const [variant, setVariant] = useState("text");
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { user } = useContext(UserContext);
   const handleClick = () => {
-    user ? navigate(`/new/bass`) : navigate('/login')
-  }
+    user ? navigate(`/new/bass`) : navigate("/login");
+  };
 
-  useEffect(()=> {
-    const urlData = location.pathname.split('/')
-    console.log(urlData)
-    const path = urlData[2]
-    if(path === 'bass') {
-      setVariant("contained")
+  useEffect(() => {
+    const urlData = location.pathname.split("/");
+    console.log(urlData);
+    const path = urlData[2];
+    if (path === "bass") {
+      setVariant("contained");
     } else {
-      setVariant("text")
+      setVariant("text");
     }
-  }, [location, user])
+  }, [location, user]);
 
   return (
     <Button
       startIcon={<AddCircleIcon />}
       onClick={handleClick}
-      sx={{justifyContent: 'left', pl: '16px', my: 1}}
+      sx={{ justifyContent: "left", pl: "16px", my: 1 }}
       disableElevation
       variant={variant}
     >
       Add Bass Tab
     </Button>
-  )
+  );
+};
 
-}
-
-export default CreateBassTabButton
+export default CreateBassTabButton;

--- a/src/pages/Home/components/Sidebar/components/CreateGuitarTabButton/CreateGuitarTabButton.js
+++ b/src/pages/Home/components/Sidebar/components/CreateGuitarTabButton/CreateGuitarTabButton.js
@@ -4,41 +4,40 @@ import { useContext, useState, useEffect } from "react";
 import { UserContext } from "containers/CognitoUserProvider/CognitoUserProvider";
 
 // MUI
-import AddCircleIcon from '@mui/icons-material/AddCircle';
-import Button from '@mui/material/Button';
+import AddCircleIcon from "@mui/icons-material/AddCircle";
+import Button from "@mui/material/Button";
 
-const CreateGuitarTabButton = () => {  
-  const [variant, setVariant] = useState("text")
-  const navigate = useNavigate()
-  const location = useLocation()
-  const { user } = useContext(UserContext)
+const CreateGuitarTabButton = () => {
+  const [variant, setVariant] = useState("text");
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { user } = useContext(UserContext);
   const handleClick = () => {
-    user ? navigate(`/new/guitar`) : navigate('/login')
-  }
+    user ? navigate(`/new/guitar`) : navigate("/login");
+  };
 
-  useEffect(()=> {
-    const urlData = location.pathname.split('/')
-    console.log(urlData)
-    const path = urlData[2]
-    if(path === 'guitar') {
-      setVariant("contained")
+  useEffect(() => {
+    const urlData = location.pathname.split("/");
+    console.log(urlData);
+    const path = urlData[2];
+    if (path === "guitar") {
+      setVariant("contained");
     } else {
-      setVariant("text")
+      setVariant("text");
     }
-  }, [location, user])
-  
+  }, [location, user]);
+
   return (
     <Button
       startIcon={<AddCircleIcon />}
       onClick={handleClick}
-      sx={{justifyContent: 'left', pl: '16px', my: 1}}
+      sx={{ justifyContent: "left", pl: "16px", my: 1 }}
       disableElevation
       variant={variant}
     >
       Add Guitar Tab
     </Button>
-  )
+  );
+};
 
-}
-
-export default CreateGuitarTabButton
+export default CreateGuitarTabButton;

--- a/src/pages/Home/components/Sidebar/components/TagSuggestions/TagSuggestions.js
+++ b/src/pages/Home/components/Sidebar/components/TagSuggestions/TagSuggestions.js
@@ -1,6 +1,6 @@
 // MUI
-import Stack from '@mui/material/Stack';
-import Button from '@mui/material/Button';
+import Stack from "@mui/material/Stack";
+import Button from "@mui/material/Button";
 
 const presetTags = [
   "Tasters",
@@ -18,23 +18,23 @@ const presetTags = [
   "R&B",
   "Metallica",
   "AC/DC",
-]
+];
 
 function TagSuggestions(props) {
   return (
     <Stack direction="column">
       {presetTags.map((tag, i) => (
-        <Button 
-          key={i} 
-          variant="text" 
+        <Button
+          key={i}
+          variant="text"
           onClick={() => props.addTag(tag)}
-          sx={{justifyContent: 'start', pl: '16px'}}
+          sx={{ justifyContent: "start", pl: "16px" }}
         >
           {tag}
-        </Button>        
-      ))}        
+        </Button>
+      ))}
     </Stack>
-  )
+  );
 }
 
-export default TagSuggestions
+export default TagSuggestions;

--- a/src/pages/Home/components/Sidebar/components/TagSuggestions/TagSuggestions.test.js
+++ b/src/pages/Home/components/Sidebar/components/TagSuggestions/TagSuggestions.test.js
@@ -1,20 +1,18 @@
-import renderer from 'react-test-renderer';
+import renderer from "react-test-renderer";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import TagSuggestions from './TagSuggestions';
+import TagSuggestions from "./TagSuggestions";
 
-const mockAddTag = jest.fn(tag => tag)
+const mockAddTag = jest.fn((tag) => tag);
 
-test('renders correctly', () => {
-  const tree = renderer
-  .create(<TagSuggestions />)
-  .toJSON();
+test("renders correctly", () => {
+  const tree = renderer.create(<TagSuggestions />).toJSON();
   expect(tree).toMatchSnapshot();
-})
+});
 
-test('clicking a button passes the tag to the onClick function', async ()=> {
-  render(<TagSuggestions addTag={mockAddTag} />)
-  const user = userEvent.setup()
-  await user.click(screen.getByText('Tasters'))
-  expect(mockAddTag).toHaveBeenCalledWith('Tasters');
-})
+test("clicking a button passes the tag to the onClick function", async () => {
+  render(<TagSuggestions addTag={mockAddTag} />);
+  const user = userEvent.setup();
+  await user.click(screen.getByText("Tasters"));
+  expect(mockAddTag).toHaveBeenCalledWith("Tasters");
+});

--- a/src/pages/Home/components/TagBar/TagBar.js
+++ b/src/pages/Home/components/TagBar/TagBar.js
@@ -1,17 +1,16 @@
 // Components / Hooks
 import { useState, useEffect } from "react";
-import { useLocation} from "react-router-dom";
+import { useLocation } from "react-router-dom";
 
 // MUI
 import { Box } from "@mui/system";
 import { Button, Chip } from "@mui/material";
 
-
 function TagBar(props) {
   const [searchInputValue, setSearchInputValue] = useState("");
   const location = useLocation();
   const [placeholder, setPlaceholder] = useState();
-  
+
   const handleSubmit = (event) => {
     event.preventDefault();
     props.addTag(searchInputValue);
@@ -48,12 +47,12 @@ function TagBar(props) {
   };
 
   useEffect(() => {
-    if(location.pathname.startsWith("/new")) {
-      setPlaceholder("add a tag")
+    if (location.pathname.startsWith("/new")) {
+      setPlaceholder("add a tag");
     } else {
-      setPlaceholder("Search")
+      setPlaceholder("Search");
     }
-  }, [location])
+  }, [location]);
 
   return (
     <>
@@ -75,8 +74,7 @@ function TagBar(props) {
             onChange={(e) => setSearchInputValue(e.target.value)}
           ></input>
         </form>
-        {props.tags.length > 0 && 
-        <Button onClick={handleClearTags}>X</Button>}
+        {props.tags.length > 0 && <Button onClick={handleClearTags}>X</Button>}
       </Box>
     </>
   );

--- a/src/services/profileServices.js
+++ b/src/services/profileServices.js
@@ -52,12 +52,17 @@ const getUsersPublicInfo = async (username) => {
   return response.json();
 };
 
-const handleLikingTablature = async (action,profile_id, likedTablature_id, idToken) => { 
+const handleLikingTablature = async (
+  action,
+  profile_id,
+  likedTablature_id,
+  idToken
+) => {
   const payload = {
     profile_id,
     likedTablature_id,
-    action
-  }
+    action,
+  };
 
   const response = await fetch(`${BASE_URL}/profile/like`, {
     method: "PATCH",
@@ -68,6 +73,11 @@ const handleLikingTablature = async (action,profile_id, likedTablature_id, idTok
     body: JSON.stringify(payload),
   });
   return response.json();
-}
+};
 
-export { create, getUsersPublicInfo, getProfileOfLoggedInUser, handleLikingTablature };
+export {
+  create,
+  getUsersPublicInfo,
+  getProfileOfLoggedInUser,
+  handleLikingTablature,
+};

--- a/src/services/tablatureServices.js
+++ b/src/services/tablatureServices.js
@@ -28,7 +28,6 @@ const create = async (tablature, idToken) => {
  * @returns {Object} { status: "" }
  */
 const update = async (tablature, idToken) => {
-
   const response = await fetch(`${BASE_URL}/tablature/${tablature._id}`, {
     method: "PUT",
     headers: {

--- a/src/utils/TestUtils/TestTabObject.js
+++ b/src/utils/TestUtils/TestTabObject.js
@@ -1,22 +1,22 @@
 export const testTab = {
   tags: [],
-  name: 'test tab',
+  name: "test tab",
   blocks: [
     {
-      label: 'test bar A',
-      inputs: 'test inputs A',
-      dashes: 'test dashes A',
-      blockTyle: 'tablature'
+      label: "test bar A",
+      inputs: "test inputs A",
+      dashes: "test dashes A",
+      blockTyle: "tablature",
     },
     {
-      label: 'test bar B',
-      inputs: 'test inputs B',
-      dashes: 'test dashes B',
-      blockTyle: 'tablature'
-    }
+      label: "test bar B",
+      inputs: "test inputs B",
+      dashes: "test dashes B",
+      blockTyle: "tablature",
+    },
   ],
   owner: {
-    user: 'testUser',
-    preferredUsername: 'JarJar_Binks',
-  }
-}
+    user: "testUser",
+    preferredUsername: "JarJar_Binks",
+  },
+};

--- a/src/utils/TestUtils/TestUtils.js
+++ b/src/utils/TestUtils/TestUtils.js
@@ -1,56 +1,56 @@
 import { render } from "@testing-library/react";
-import {BrowserRouter} from 'react-router-dom'
+import { BrowserRouter } from "react-router-dom";
 import { UserContext } from "containers/CognitoUserProvider/CognitoUserProvider";
 const mockUser = {
   value: {
     user: {
-      username: 'JarJar_Binks',
+      username: "JarJar_Binks",
       userDataKey: "pizza",
-      storage: {}
-    }
-  }
-}
+      storage: {},
+    },
+  },
+};
 
 export const renderWithUserContext = (ui) => {
   return render(
     <UserContext.Provider {...mockUser}>{ui}</UserContext.Provider>,
-    {wrapper: BrowserRouter},
-  )
-}
+    { wrapper: BrowserRouter }
+  );
+};
 
 export const wrapInUserContext = (ui) => {
   return (
     <BrowserRouter>
       <UserContext.Provider {...mockUser}>{ui}</UserContext.Provider>
     </BrowserRouter>
-  )
-}
+  );
+};
 
 export const sampleTablatureBlock = {
-  inputs: 'test inputs',
-  dashes: 'test dashes',
-  blockType: 'tablature'
-}
+  inputs: "test inputs",
+  dashes: "test dashes",
+  blockType: "tablature",
+};
 
 export const testTab = {
   tags: [],
-  name: 'test tab',
+  name: "test tab",
   blocks: [
     {
-      label: 'test bar A',
-      inputs: 'test inputs A',
-      dashes: 'test dashes A',
-      blockTyle: 'tablature'
+      label: "test bar A",
+      inputs: "test inputs A",
+      dashes: "test dashes A",
+      blockTyle: "tablature",
     },
     {
-      label: 'test bar B',
-      inputs: 'test inputs B',
-      dashes: 'test dashes B',
-      blockTyle: 'tablature'
-    }
+      label: "test bar B",
+      inputs: "test inputs B",
+      dashes: "test dashes B",
+      blockTyle: "tablature",
+    },
   ],
   owner: {
-    user: 'testUser',
-    preferredUsername: 'JarJar_Binks',
-  }
-}
+    user: "testUser",
+    preferredUsername: "JarJar_Binks",
+  },
+};


### PR DESCRIPTION
### **Theme updates**

**Sidebar**
Sidebar is now updated with minWidth parameters to prevent being overlapped/squished by the tag search bar. 
Still left to-do
- Adjust and reconfig `"Create"` dropdown size it's two links have been disabled/relocated to the sidebar
- Once adjusted, figure out breakpoint layouts per screensize change

**Breakpoints**
Breakpoints are now stubbed up in the `Theme.js` with the following variants:
- `mobile: 0`
- `tablet: 640`
- `laptop: 1024`
- `desktop: 1200`

These are subject to change as needed but general suggested values. 

**Prettier**
ran the `npx prettier --write .` command on the project again just to assist with gradual clean-up. I know of one prior spot where Prettier reformatted a code line against Ryan's preferences. If you see anything while reviewing or after merging, feel free to adjust or let me know to adjust. We can keep a note of those areas so I can make those adjustments with each Prettier config.

