### PR TITLE
Editor UI / UX updates

### DIFF
--- a/src/Theme.js
+++ b/src/Theme.js
@@ -23,19 +23,6 @@ const darkTheme = createTheme({
     },
   },
   components: {
-    MuiChip: {
-      styleOverrides: {
-        root: {
-        },
-      },
-    },
-    Box: {
-      styleOverrides: {
-        root: {
-          // background: "transparent",
-        }
-      }
-    },
   },
   typography: {
     // Main Header

--- a/src/Theme.js
+++ b/src/Theme.js
@@ -17,7 +17,7 @@ const darkTheme = createTheme({
       main: "#D5A419",
     },
     error: {
-      main: "#EA0004",
+      main: "#BF616A",
       light: "#FF8670",
       dark: "#640006",
     },

--- a/src/pages/Home/components/RiffinEditor/RiffinEditor.js
+++ b/src/pages/Home/components/RiffinEditor/RiffinEditor.js
@@ -15,14 +15,14 @@ const RiffinEditor = () => {
   return (
     <Box sx={{mb: 12}}>
       <Grid container rowSpacing={2} columnSpacing={4} sx={{alignItems: "end"}}>
-        <Grid item>
+        <Grid item xs={12}>
           <TitleInput />
         </Grid>
         <Grid item>
           <SaveTabButton />
         </Grid>
         <Grid item>
-          <DeleteTabButton />
+          <DeleteTabButton disabled={!editor.tablature._id} />
         </Grid>
         <Grid item>
           <ModeSwitch />

--- a/src/pages/Home/components/RiffinEditor/RiffinEditor.js
+++ b/src/pages/Home/components/RiffinEditor/RiffinEditor.js
@@ -4,12 +4,17 @@ import TitleInput from "./components/TitleInput/TitleInput";
 import TablatureBlock from "./components/TablatureBlock/TablatureBlock";
 import { useContext } from "react";
 import { RiffinEditorDispatch } from "./RiffinProvider";
-// MUI
-import { Box, Grid } from "@mui/material";
 import BlockContent from "components/Card/components/BlockContent/BlockContent";
 import SaveTabButton from "./components/SaveTabButton/SaveTabButton";
 import DeleteTabButton from "./components/DeleteTabButton/DeleteTabButton";
 import ModeSwitch from "./components/ModeSwitch/ModeSwitch";
+// MUI
+import { Box, Grid } from "@mui/material";
+
+/**
+ * * Displays the fields for editing a tablature.
+ * @returns 
+ */
 const RiffinEditor = () => {
   const { editor } = useContext(RiffinEditorDispatch);
   return (

--- a/src/pages/Home/components/RiffinEditor/RiffinEditor.js
+++ b/src/pages/Home/components/RiffinEditor/RiffinEditor.js
@@ -7,6 +7,9 @@ import { RiffinEditorDispatch } from "./RiffinProvider";
 // MUI
 import { Box, Grid } from "@mui/material";
 import BlockContent from "components/Card/components/BlockContent/BlockContent";
+import SaveTabButton from "./components/SaveTabButton/SaveTabButton";
+import DeleteTabButton from "./components/DeleteTabButton/DeleteTabButton";
+import ModeSwitch from "./components/ModeSwitch/ModeSwitch";
 const RiffinEditor = () => {
   const { editor } = useContext(RiffinEditorDispatch);
   return (
@@ -14,6 +17,15 @@ const RiffinEditor = () => {
       <Grid container rowSpacing={2} columnSpacing={4} sx={{alignItems: "end"}}>
         <Grid item>
           <TitleInput />
+        </Grid>
+        <Grid item>
+          <SaveTabButton />
+        </Grid>
+        <Grid item>
+          <DeleteTabButton />
+        </Grid>
+        <Grid item>
+          <ModeSwitch />
         </Grid>
       </Grid>
       {editor.previewMode

--- a/src/pages/Home/components/RiffinEditor/RiffinProvider.js
+++ b/src/pages/Home/components/RiffinEditor/RiffinProvider.js
@@ -7,6 +7,7 @@ import { TagContext } from "containers/TagProvider/TagProvider";
 // Utilties
 import * as utils from "./Utilities";
 
+// * RiffinEditor and RiffinDrawer must be children of RiffinProvider for the editor to work. This provider handles the editor data.
 // * RiffinProvider relies on this dispatch context to update state values from child components.
 // * Checkout React's documentation for more information:
 // * https://reactjs.org/docs/hooks-reference.html#usereducer

--- a/src/pages/Home/components/RiffinEditor/components/DeleteTabButton/DeleteTabButton.js
+++ b/src/pages/Home/components/RiffinEditor/components/DeleteTabButton/DeleteTabButton.js
@@ -12,8 +12,8 @@ import { Button } from "@mui/material";
 import DeleteIcon from '@mui/icons-material/Delete';
 
 /**
- *  * No dispatch is sent to the RiffinEditor since deleting navigates the user.
- *  props: tablature
+ *  * Handles deleting the tablature. No dispatch is sent to the RiffinEditor since deleting navigates the user.
+ *  props: tablature, disabled
  */
 
 const DeleteTabButton = (props) => {

--- a/src/pages/Home/components/RiffinEditor/components/DeleteTabButton/DeleteTabButton.js
+++ b/src/pages/Home/components/RiffinEditor/components/DeleteTabButton/DeleteTabButton.js
@@ -37,7 +37,13 @@ const DeleteTabButton = (props) => {
   };
   
   return (
-    <Button variant="outlined" onClick={handleDelete}>Delete</Button>
+    <Button 
+      variant="outlined" 
+      onClick={handleDelete}
+      disabled={props.disabled}
+    >
+      Delete
+    </Button>
   );
 };
  

--- a/src/pages/Home/components/RiffinEditor/components/DeleteTabButton/DeleteTabButton.js
+++ b/src/pages/Home/components/RiffinEditor/components/DeleteTabButton/DeleteTabButton.js
@@ -9,6 +9,7 @@ import * as tablatureServices from "services/tablatureServices";
 import { getIdTokenFromUser } from "utils/userUtils";
 // MUI
 import { Button } from "@mui/material";
+import DeleteIcon from '@mui/icons-material/Delete';
 
 /**
  *  * No dispatch is sent to the RiffinEditor since deleting navigates the user.
@@ -41,6 +42,8 @@ const DeleteTabButton = (props) => {
       variant="outlined" 
       onClick={handleDelete}
       disabled={props.disabled}
+      color="error"
+      endIcon={<DeleteIcon />}
     >
       Delete
     </Button>

--- a/src/pages/Home/components/RiffinEditor/components/ModeSwitch/ModeSwitch.js
+++ b/src/pages/Home/components/RiffinEditor/components/ModeSwitch/ModeSwitch.js
@@ -1,10 +1,19 @@
+// Components / hooks
+import { RiffinEditorDispatch } from '../../RiffinProvider';
+import { useState, useContext } from 'react';
+// MUI
 import { styled } from '@mui/material/styles';
 import FormGroup from '@mui/material/FormGroup';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import Switch from '@mui/material/Switch';
-import { RiffinEditorDispatch } from '../../RiffinProvider';
-import { useState, useContext } from 'react';
 
+/**
+ * * Switch that changes which mode the editor is in. There are 2 modes: Edit, Preview. Edit mode allows the user to edit the tablature and displays all editor controls. Preview mode allows the user to preview the tablature as if it were on the collections page.
+ */
+
+/**
+ * This builds the style of the switch and is straight from the MUI documentation.
+ */
 const MaterialUISwitch = styled(Switch)(({ theme }) => ({
   width: 62,
   height: 34,
@@ -56,7 +65,9 @@ const MaterialUISwitch = styled(Switch)(({ theme }) => ({
 export default function ModeSwitch() {
   const [previewMode, setPreviewMode] = useState(false);
   const { dispatch } = useContext(RiffinEditorDispatch);
-  
+  /**
+   * Dispatches a setPreviewMode action to the editor and updates the switch component state.
+   */
   const handleChange = () => {
     const action = {
       type: 'setPreviewMode',

--- a/src/pages/Home/components/RiffinEditor/components/ModeSwitch/ModeSwitch.js
+++ b/src/pages/Home/components/RiffinEditor/components/ModeSwitch/ModeSwitch.js
@@ -53,7 +53,7 @@ const MaterialUISwitch = styled(Switch)(({ theme }) => ({
   },
 }));
 
-export default function CustomizedSwitches() {
+export default function ModeSwitch() {
   const [previewMode, setPreviewMode] = useState(false);
   const { dispatch } = useContext(RiffinEditorDispatch);
   
@@ -69,7 +69,7 @@ export default function CustomizedSwitches() {
   return (
     <FormGroup>
       <FormControlLabel
-        control={<MaterialUISwitch onChange={handleChange} sx={{ m: 1, mr: 0 }} />}
+        control={<MaterialUISwitch onChange={handleChange} />}
         label="Display mode"
       />
     </FormGroup>

--- a/src/pages/Home/components/RiffinEditor/components/RiffinDrawer/RiffinDrawer.js
+++ b/src/pages/Home/components/RiffinEditor/components/RiffinDrawer/RiffinDrawer.js
@@ -6,7 +6,8 @@ import DuplicateBlockButton from "./components/DuplicateBlockButton/DuplicateBlo
 import DeleteBlockButton from "./components/DeleteBlockButton/DeleteBlockButton";
 import Legend from "./components/Legend/Legend";
 // MUI
-import { Box, Container, Divider, Stack, Typography } from "@mui/material";
+import { Box, Container, Stack, Typography } from "@mui/material";
+import StaffMenuHeader from "./components/StaffMenuHeader/StaffMenuHeader";
 
 /**
  * * The RiffinDrawer sits next to the RiffinEditor and provides additional controls for the selected block, as well as a legend that displays special inputs and tablature notation.
@@ -30,7 +31,7 @@ const RiffinDrawer = () => {
       {!editor.previewMode &&
         <Container sx={{mt: 4}}>
             <Stack spacing={2} sx={{my: 4}}>
-              <Divider>Staff menu</Divider>
+              <StaffMenuHeader />
               <Box>
                 <Typography>Size</Typography>
                 <SizeSlider block={ selectedBlock }/>

--- a/src/pages/Home/components/RiffinEditor/components/RiffinDrawer/RiffinDrawer.js
+++ b/src/pages/Home/components/RiffinEditor/components/RiffinDrawer/RiffinDrawer.js
@@ -21,32 +21,23 @@ const RiffinDrawer = () => {
   }, [editor])
 
   return (
-    <>
-      <Container sx={{mt: 4}}>
-        <Stack spacing={2}>
-          <CustomizedSwitches />
-          <SaveTabButton />
-          {editor.tablature._id &&
-            <DeleteTabButton />
-          }
-        </Stack>
-        {!editor.previewMode &&
-        <>        
-          <Stack spacing={2} sx={{my: 4}}>
-            <Divider>Staff menu</Divider>
-            <Box>
-              <Typography>Size</Typography>
-              <SizeSlider block={ selectedBlock }/>
-            </Box>
-            <DuplicateBlockButton />
-            <DeleteBlockButton block={ selectedBlock } disabled={(editor.tablature.blocks.length === 1)} />
-          </Stack>
-          <Divider />
+    <Container sx={{mt: 4}}>
+      {!editor.previewMode &&
+        <Stack spacing={2} sx={{my: 4}}>
+          <Divider>Staff menu</Divider>
+          <Box>
+            <Typography>Size</Typography>
+            <SizeSlider block={ selectedBlock }/>
+          </Box>
+          <DuplicateBlockButton />
+          <DeleteBlockButton 
+            block={ selectedBlock } 
+            disabled={(editor.tablature.blocks.length === 1)} 
+          />
           <Legend />
-        </>
-        }
-      </Container>
-    </>
+        </Stack>
+      }
+    </Container>
   );
 }
  

--- a/src/pages/Home/components/RiffinEditor/components/RiffinDrawer/RiffinDrawer.js
+++ b/src/pages/Home/components/RiffinEditor/components/RiffinDrawer/RiffinDrawer.js
@@ -1,43 +1,50 @@
+// Components / hooks
 import { useContext, useState, useEffect } from "react";
 import SizeSlider from "./components/SizeSlider/SizeSlider";
 import { RiffinEditorDispatch } from "../../RiffinProvider";
 import DuplicateBlockButton from "./components/DuplicateBlockButton/DuplicateBlockButton";
-
-import { Box, Container, Divider, Stack, Typography } from "@mui/material";
 import DeleteBlockButton from "./components/DeleteBlockButton/DeleteBlockButton";
-import SaveTabButton from "../SaveTabButton/SaveTabButton";
-import DeleteTabButton from "../DeleteTabButton/DeleteTabButton";
-import CustomizedSwitches from "../ModeSwitch/ModeSwitch";
 import Legend from "./components/Legend/Legend";
+// MUI
+import { Box, Container, Divider, Stack, Typography } from "@mui/material";
 
+/**
+ * * The RiffinDrawer sits next to the RiffinEditor and provides additional controls for the selected block, as well as a legend that displays special inputs and tablature notation.
+ * @returns 
+ */
 const RiffinDrawer = () => {
   const { editor } = useContext(RiffinEditorDispatch);
-  const [selectedBlock, setBlock] = useState(editor.tablature.blocks[editor.selectedBlock.index]);
+  const [selectedBlock, setBlock] = useState({...editor.tablature.blocks[editor.selectedBlock.index]});
 
+  /**
+   * This useEffect tells the children of the drawer which block is selected. The children cannot mutate editor.selectedBlock via sending dispatch requests as it will cause issues, mainly because reducer updates do not happen until rerendering while some components, such as the slider, require immediate updates of the block object.
+   */
   useEffect(() => {
     if(editor.selectedBlock.block) {
-      setBlock(editor.tablature.blocks[editor.selectedBlock.index]);
+      setBlock({...editor.tablature.blocks[editor.selectedBlock.index]});
     }
-  }, [editor])
+  }, [editor]);
 
   return (
-    <Container sx={{mt: 4}}>
+    <>    
       {!editor.previewMode &&
-        <Stack spacing={2} sx={{my: 4}}>
-          <Divider>Staff menu</Divider>
-          <Box>
-            <Typography>Size</Typography>
-            <SizeSlider block={ selectedBlock }/>
-          </Box>
-          <DuplicateBlockButton />
-          <DeleteBlockButton 
-            block={ selectedBlock } 
-            disabled={(editor.tablature.blocks.length === 1)} 
-          />
-          <Legend />
-        </Stack>
+        <Container sx={{mt: 4}}>
+            <Stack spacing={2} sx={{my: 4}}>
+              <Divider>Staff menu</Divider>
+              <Box>
+                <Typography>Size</Typography>
+                <SizeSlider block={ selectedBlock }/>
+              </Box>
+              <DuplicateBlockButton />
+              <DeleteBlockButton 
+                block={ selectedBlock } 
+                disabled={(editor.tablature.blocks.length === 1)} 
+              />
+              <Legend />
+            </Stack>
+        </Container>
       }
-    </Container>
+    </>
   );
 }
  

--- a/src/pages/Home/components/RiffinEditor/components/RiffinDrawer/components/DeleteBlockButton/DeleteBlockButton.js
+++ b/src/pages/Home/components/RiffinEditor/components/RiffinDrawer/components/DeleteBlockButton/DeleteBlockButton.js
@@ -9,6 +9,12 @@ const buttonStyle = {
   width: "100%"
 }
 
+/**
+ * * Handles deleting the selected block. A dispatch is sent out to handle deleting.
+ * @param {Object} props - disabled
+ * @returns 
+ */
+
 const DeleteBlockButton = (props) => {
   const { dispatch } = useContext(RiffinEditorDispatch);
   /**

--- a/src/pages/Home/components/RiffinEditor/components/RiffinDrawer/components/DeleteBlockButton/DeleteBlockButton.js
+++ b/src/pages/Home/components/RiffinEditor/components/RiffinDrawer/components/DeleteBlockButton/DeleteBlockButton.js
@@ -30,7 +30,7 @@ const DeleteBlockButton = (props) => {
           onClick={handleDelete}
           variant="outlined"
           sx={buttonStyle}
-          color="tabInput"
+          color="error"
           disabled={props.disabled}
         >
           Delete

--- a/src/pages/Home/components/RiffinEditor/components/RiffinDrawer/components/DeleteBlockButton/DeleteBlockButton.js
+++ b/src/pages/Home/components/RiffinEditor/components/RiffinDrawer/components/DeleteBlockButton/DeleteBlockButton.js
@@ -1,5 +1,8 @@
+// Components / hooks
 import { useContext } from "react";
 import { RiffinEditorDispatch } from "pages/Home/components/RiffinEditor/RiffinProvider";
+// MUI
+import DeleteIcon from '@mui/icons-material/Delete';
 import { Button, Tooltip } from "@mui/material";
 
 const buttonStyle = {
@@ -23,9 +26,11 @@ const DeleteBlockButton = (props) => {
     <Tooltip title={props.disabled ? "You cannot delete the only block" : "" }>
       <span>
         <Button 
+          endIcon={<DeleteIcon />}
           onClick={handleDelete}
           variant="outlined"
           sx={buttonStyle}
+          color="tabInput"
           disabled={props.disabled}
         >
           Delete

--- a/src/pages/Home/components/RiffinEditor/components/RiffinDrawer/components/DuplicateBlockButton/DuplicateBlockButton.js
+++ b/src/pages/Home/components/RiffinEditor/components/RiffinDrawer/components/DuplicateBlockButton/DuplicateBlockButton.js
@@ -1,10 +1,12 @@
+// Components / hooks
 import { useContext } from "react";
 import { RiffinEditorDispatch } from "pages/Home/components/RiffinEditor/RiffinProvider";
+// MUI
 import { Button } from "@mui/material";
 
 const buttonStyle = {
-  width: "100%"
-}
+  width: "100%",
+};
 
 const DuplicateBlockButton = () => {
   const { dispatch } = useContext(RiffinEditorDispatch);
@@ -16,12 +18,13 @@ const DuplicateBlockButton = () => {
       type: 'duplicateBlock',
     };
     dispatch(action);
-  }
+  };
 
   return (
     <Button 
       onClick={handleDuplicate}
       variant="outlined"
+      color="tabInput"
       sx={buttonStyle}
     >
       Duplicate

--- a/src/pages/Home/components/RiffinEditor/components/RiffinDrawer/components/Legend/Legend.js
+++ b/src/pages/Home/components/RiffinEditor/components/RiffinDrawer/components/Legend/Legend.js
@@ -1,9 +1,15 @@
+// Utilities
+import SimpleBar from 'simplebar-react';
+import 'simplebar-react/dist/simplebar.min.css';
+// MUI
 import { ListItemButton } from '@mui/material';
 import List from '@mui/material/List';
 import ListItemText from '@mui/material/ListItemText';
 import ListSubheader from '@mui/material/ListSubheader';
-import SimpleBar from 'simplebar-react';
-import 'simplebar-react/dist/simplebar.min.css';
+
+/**
+ * This object is used to build the legend List.
+ */
 const legend = [
   {
     subheader: 'Special inputs',
@@ -51,31 +57,52 @@ const legend = [
       },
     ]
   },
-]
+];
 
+const listStyles = {
+  width: '100%',
+  maxWidth: 360,
+  bgcolor: 'background.default',
+  position: 'relative',
+  '& ul': { padding: 0 },
+};
+
+const subHeaderStyles = {
+  bgcolor: 'background.default', 
+  color: 'primary.main'
+};
+
+const listItemValueStyles = {
+  fontSize: '18px', 
+  color: 'tabInput.main'
+};
+
+const listItemLabelStyles = {
+  textAlign: 'right',
+  fontSize: '14px'
+};
+
+/**
+ * * The legend displays inputs and tablature notation to the user in the form of buttons. The buttons will eventually have functionality to edit the selected block when clicked. The SimpleBar package is used to scroll through the legend once a set size is decided on. Currently the legend's full height is displayed.
+ * @returns 
+ */
 export default function Legend() {
   return (
     <SimpleBar>
       <List
-        sx={{
-          width: '100%',
-          maxWidth: 360,
-          bgcolor: 'background.default',
-          position: 'relative',
-          '& ul': { padding: 0 },
-        }}
+        sx={listStyles}
         subheader={<li />}
       >
         {legend.map((section) => (
           <li key={`section-${section.subheader}`}>
             <ul>
-              <ListSubheader sx={{bgcolor: 'background.default', color: 'primary.main'}}>{`${section.subheader}`}</ListSubheader>
+              <ListSubheader sx={subHeaderStyles}>{`${section.subheader}`}</ListSubheader>
               {section.items.map((item, i) => (
                 <ListItemButton key={`item-${section.subheader}-${item.value}`}>
-                    <ListItemText sx={{fontSize: '18px', color: 'tabInput.main'}} primary={`${item.value}`} />
-                    <div style={{textAlign: 'right', fontSize: '14px'}}>
-                      <ListItemText primary={`${item.label}`} />
-                    </div>
+                  <ListItemText sx={listItemValueStyles} primary={`${item.value}`} />
+                  <div style={listItemLabelStyles}>
+                    <ListItemText primary={`${item.label}`} />
+                  </div>
                 </ListItemButton>
               ))}
             </ul>

--- a/src/pages/Home/components/RiffinEditor/components/RiffinDrawer/components/SizeSlider/SizeSlider.js
+++ b/src/pages/Home/components/RiffinEditor/components/RiffinDrawer/components/SizeSlider/SizeSlider.js
@@ -69,6 +69,7 @@ const SizeSlider = (props) => {
       onChange={handleSliderChange}
       min={MIN_BLOCK_COLS}
       max={MAX_BLOCK_COLS}
+      color="tabInput"
     />
   );
 }

--- a/src/pages/Home/components/RiffinEditor/components/RiffinDrawer/components/StaffMenuHeader/StaffMenuHeader.js
+++ b/src/pages/Home/components/RiffinEditor/components/RiffinDrawer/components/StaffMenuHeader/StaffMenuHeader.js
@@ -20,7 +20,7 @@ const StaffMenuHeader = () => {
     <Divider>
       <Box sx={wrapperStyle}>
         Staff Menu
-        <Tooltip sx={tooltipStyle} title="This menu provides additional options for the selected staff. The currently selected staff is colorized, while deslected staff appear grayed out.">
+        <Tooltip sx={tooltipStyle} title="This menu provides additional options for the selected staff. The currently selected staff is colorized while deslected staff appear grayed out.">
           <HelpIcon />
         </Tooltip>
       </Box>

--- a/src/pages/Home/components/RiffinEditor/components/RiffinDrawer/components/StaffMenuHeader/StaffMenuHeader.js
+++ b/src/pages/Home/components/RiffinEditor/components/RiffinDrawer/components/StaffMenuHeader/StaffMenuHeader.js
@@ -1,0 +1,31 @@
+// MUI
+import { Box, Divider, Tooltip } from "@mui/material";
+import HelpIcon from '@mui/icons-material/Help';
+
+const wrapperStyle = { 
+  display: 'flex', 
+  alignItems: 'center'
+};
+
+const tooltipStyle = {
+  m: 1
+};
+
+/**
+ * Providers a header and tooltip for the staff menu.
+ * @returns 
+ */
+const StaffMenuHeader = () => {
+  return (
+    <Divider>
+      <Box sx={wrapperStyle}>
+        Staff Menu
+        <Tooltip sx={tooltipStyle} title="This menu provides additional options for the selected staff. The currently selected staff is colorized">
+          <HelpIcon />
+        </Tooltip>
+      </Box>
+    </Divider>
+  );
+}
+ 
+export default StaffMenuHeader;

--- a/src/pages/Home/components/RiffinEditor/components/RiffinDrawer/components/StaffMenuHeader/StaffMenuHeader.js
+++ b/src/pages/Home/components/RiffinEditor/components/RiffinDrawer/components/StaffMenuHeader/StaffMenuHeader.js
@@ -20,7 +20,7 @@ const StaffMenuHeader = () => {
     <Divider>
       <Box sx={wrapperStyle}>
         Staff Menu
-        <Tooltip sx={tooltipStyle} title="This menu provides additional options for the selected staff. The currently selected staff is colorized">
+        <Tooltip sx={tooltipStyle} title="This menu provides additional options for the selected staff. The currently selected staff is colorized, while deslected staff appear grayed out.">
           <HelpIcon />
         </Tooltip>
       </Box>

--- a/src/pages/Home/components/RiffinEditor/components/TitleInput/TitleInput.js
+++ b/src/pages/Home/components/RiffinEditor/components/TitleInput/TitleInput.js
@@ -27,6 +27,7 @@ const TitleInput = () => {
       variant="standard" 
       onChange={handleChange}
       value={editor.tablature.name || ""}
+      sx={{width: '50%'}}
     />
   );
 }


### PR DESCRIPTION
Applied UI/UX updates after meeting with the UI/UX wizards.

* The RiffinDrawer now only shows inputs related to the selected block
* Save, Delete, Display mode have been moved below the tablature title as to indicate their functionality belongs to the tablature as a whole
* Block controls and general editor controls are color coded to help the user associate the difference between the 2
* A tooltip was added to the staff menu to give the user some direction.