### PR TITLE
Issue #99

### DIFF
--- a/src/Theme.js
+++ b/src/Theme.js
@@ -75,7 +75,7 @@ const darkTheme = createTheme({
       fontWeight: 400,
       lineHeight: "120%",
       textAlign: "left",
-      whiteSpace: "pre-line",
+      whiteSpace: "pre-wrap",
       [`@media screen and (max-width: 1200px)`]: {
         fontSize: "14px",
       },
@@ -243,7 +243,7 @@ const theme = createTheme({
       fontStyle: "normal",
       fontWeight: 400,
       lineHeight: "120%",
-      whiteSpace: "pre-line",
+      whiteSpace: "pre-wrap",
       textAlign: "left",
       [`@media screen and (max-width: 1200px)`]: {
         fontSize: "14px",

--- a/src/Theme.js
+++ b/src/Theme.js
@@ -22,8 +22,7 @@ const darkTheme = createTheme({
       dark: "#640006",
     },
   },
-  components: {
-  },
+  components: {},
   typography: {
     // Main Header
     logo: {
@@ -34,7 +33,7 @@ const darkTheme = createTheme({
       color: "#88C0D0",
       margin: "0",
     },
-    h1: { 
+    h1: {
       fontFamily: "Montserrat",
       fontWeight: 800,
       fontSize: "64px",
@@ -75,8 +74,8 @@ const darkTheme = createTheme({
       fontStyle: "normal",
       fontWeight: 400,
       lineHeight: "120%",
-      letterSpacing: "0.15px",
       textAlign: "left",
+      whiteSpace: "pre-line",
       [`@media screen and (max-width: 1200px)`]: {
         fontSize: "14px",
       },
@@ -85,7 +84,6 @@ const darkTheme = createTheme({
       fontFamily: "Montserrat",
       fontSize: "14px",
       textTransform: "uppercase",
-      letterSpacing: "0.15px",
       lineHeight: "143%",
       [`@media screen and (max-width: 1200px)`]: {
         fontSize: "12px",
@@ -241,11 +239,11 @@ const theme = createTheme({
     },
     body1: {
       fontFamily: "Montserrat",
-      fontSize: "16px",
+      fontSize: "14px",
       fontStyle: "normal",
       fontWeight: 400,
       lineHeight: "120%",
-      letterSpacing: "0.15px",
+      whiteSpace: "pre-line",
       textAlign: "left",
       [`@media screen and (max-width: 1200px)`]: {
         fontSize: "14px",
@@ -255,7 +253,7 @@ const theme = createTheme({
       fontFamily: "Montserrat",
       fontSize: "14px",
       textTransform: "uppercase",
-      letterSpacing: "0.15px",
+      // letterSpacing: "0.15px",
       lineHeight: "143%",
       [`@media screen and (max-width: 1200px)`]: {
         fontSize: "12px",

--- a/src/components/Card/components/BlockContent/BlockContent.js
+++ b/src/components/Card/components/BlockContent/BlockContent.js
@@ -2,8 +2,14 @@ import { Box, Typography } from "@mui/material";
 import ReadonlyTablature from "components/ReadonlyTablature/ReadonlyTablature";
 
 const spacerStyle = {
-  my: 1
-}
+  my: 1,
+};
+
+const notesStyle = {
+  fontFamily: "monospace",
+  fontSize: "16px",
+  fontWeight: 400,
+};
 
 const BlockContent = (props) => {
   return (
@@ -11,18 +17,18 @@ const BlockContent = (props) => {
       {props.blocks?.map((block, i) => (
         <Box key={i}>
           <Box sx={spacerStyle}>
-            <Typography>{block.label}</Typography>
+            <Typography sx={notesStyle}>{block.label}</Typography>
           </Box>
           <Box sx={spacerStyle}>
-            <ReadonlyTablature 
-              numberOfStrings={props.numberOfStrings} 
-              blockData={block} 
+            <ReadonlyTablature
+              numberOfStrings={props.numberOfStrings}
+              blockData={block}
             />
           </Box>
         </Box>
       ))}
     </>
   );
-}
- 
+};
+
 export default BlockContent;

--- a/src/pages/Home/components/RiffinEditor/components/TablatureBlock/components/NoteTextarea/NoteTextarea.js
+++ b/src/pages/Home/components/RiffinEditor/components/TablatureBlock/components/NoteTextarea/NoteTextarea.js
@@ -3,6 +3,7 @@ import { useContext } from "react";
 import { RiffinEditorDispatch } from "pages/Home/components/RiffinEditor/RiffinProvider";
 // MUI
 import { TextareaAutosize } from "@mui/material";
+import Typography from "@mui/material/Typography";
 
 /**
  * * NoteTextarea is the textarea above the tablature. It allows users to take multi-line notes. The length of the textarea fills up the space between the container's left edge and the right edge of the Options button.
@@ -18,20 +19,21 @@ const NoteTextarea = (props) => {
     outline: "none",
     border: "none",
     color: "white",
-    fontSize: "inherit",
-    padding: 0
+    fontSize: "16px",
+    padding: 0,
+    whiteSpace: "pre-line",
   };
 
   /**
    * Sends a dispatch to update the selected block. The new selected block will be whichever block is handling the click.
-   * @param {Object} event 
+   * @param {Object} event
    */
-   const handleClick = (event) => {
+  const handleClick = (event) => {
     const action = {
       type: "updateSelection",
       blockIndex: props.index,
       blockRef: null,
-      selectionStart: event.target.selectionStart
+      selectionStart: event.target.selectionStart,
     };
     dispatch(action);
   };
@@ -43,24 +45,26 @@ const NoteTextarea = (props) => {
   const handleChange = (event) => {
     event.preventDefault();
     const action = {
-      type: 'updateBlockLabel',
+      type: "updateBlockLabel",
       value: event.target.value,
-      index: props.index
+      index: props.index,
     };
     dispatch(action);
   };
 
   return (
-    <TextareaAutosize
-      spellCheck="false"
-      style={inputsStyle}
-      minRows={2}
-      value={props.label}
-      onClick={handleClick}
-      onChange={handleChange}
-      placeholder={"Notes.\nTake as many lines as you need."}
-    />
+    <Typography>
+      <TextareaAutosize
+        spellCheck="false"
+        style={inputsStyle}
+        minRows={2}
+        value={props.label}
+        onClick={handleClick}
+        onChange={handleChange}
+        placeholder={"Notes.\nTake as many lines as you need."}
+      />
+    </Typography>
   );
-}
- 
+};
+
 export default NoteTextarea;


### PR DESCRIPTION
Issue solved: https://github.com/RyanSUP/riffin-v2/issues/99

- white-space rule added to theme.js, adapting notes section of tablature
- inline styles added to notes section on BlockContent, making NoteTextarea and BlockContent identical in styling.